### PR TITLE
add a manifest and update .toml to only build src

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include README.md
+include pyproject.toml
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[cod]
+recursive-exclude tests *
+recursive-exclude docs * 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[cod]
 recursive-exclude tests *
 recursive-exclude docs * 
+recursive-exclude data_prep *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,4 @@ dependencies = [
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages.find = {where = ["src"], include = ["milliontrees*"], exclude = ["tests*", "docs*","data_prep*"]}
+packages.find = {where = ["src"], include = ["milliontrees*"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,7 @@ dependencies = [
     "torchmetrics",
     "docformatter",
 ]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages.find = {where = ["src"], include = ["milliontrees*"], exclude = ["tests*", "docs*","data_prep*"]}


### PR DESCRIPTION
Pypi was (rightly) complaining that the .tar was too large since it wrapped the entire repo. I updated the .toml and added a manifest file to help setuptools. Confirmed with 

```
(MillionTrees) (base) benweinstein@Bens-MacBook-Pro MillionTrees % python -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools-scm[toml]>=6.2.3
  - setuptools>=61
* Getting build dependencies for sdist...
running egg_info
writing src/milliontrees.egg-info/PKG-INFO
writing dependency_links to src/milliontrees.egg-info/dependency_links.txt
writing requirements to src/milliontrees.egg-info/requires.txt
writing top-level names to src/milliontrees.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[cod]' found under directory '*'
adding license file 'LICENSE'
writing manifest file 'src/milliontrees.egg-info/SOURCES.txt'
* Building sdist...
running sdist
running egg_info
writing src/milliontrees.egg-info/PKG-INFO
writing dependency_links to src/milliontrees.egg-info/dependency_links.txt
writing requirements to src/milliontrees.egg-info/requires.txt
writing top-level names to src/milliontrees.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[cod]' found under directory '*'
adding license file 'LICENSE'
writing manifest file 'src/milliontrees.egg-info/SOURCES.txt'
running check
creating milliontrees-0.1.0
creating milliontrees-0.1.0/.github/workflows
creating milliontrees-0.1.0/src/milliontrees
creating milliontrees-0.1.0/src/milliontrees.egg-info
creating milliontrees-0.1.0/src/milliontrees/common
creating milliontrees-0.1.0/src/milliontrees/common/metrics
creating milliontrees-0.1.0/src/milliontrees/datasets
creating milliontrees-0.1.0/weights
copying files to milliontrees-0.1.0...
copying .comet.config -> milliontrees-0.1.0
copying .gitignore -> milliontrees-0.1.0
copying .readthedocs.yaml -> milliontrees-0.1.0
copying .style.yapf -> milliontrees-0.1.0
copying LICENSE -> milliontrees-0.1.0
copying MANIFEST.in -> milliontrees-0.1.0
copying README.md -> milliontrees-0.1.0
copying pyproject.toml -> milliontrees-0.1.0
copying requirements.txt -> milliontrees-0.1.0
copying submit_DeepForest.sh -> milliontrees-0.1.0
copying .github/workflows/python-package.yml -> milliontrees-0.1.0/.github/workflows
copying .github/workflows/python-publish.yml -> milliontrees-0.1.0/.github/workflows
copying src/milliontrees/__init__.py -> milliontrees-0.1.0/src/milliontrees
copying src/milliontrees/download_datasets.py -> milliontrees-0.1.0/src/milliontrees
copying src/milliontrees/get_dataset.py -> milliontrees-0.1.0/src/milliontrees
copying src/milliontrees/version.py -> milliontrees-0.1.0/src/milliontrees
copying src/milliontrees.egg-info/PKG-INFO -> milliontrees-0.1.0/src/milliontrees.egg-info
copying src/milliontrees.egg-info/SOURCES.txt -> milliontrees-0.1.0/src/milliontrees.egg-info
copying src/milliontrees.egg-info/dependency_links.txt -> milliontrees-0.1.0/src/milliontrees.egg-info
copying src/milliontrees.egg-info/requires.txt -> milliontrees-0.1.0/src/milliontrees.egg-info
copying src/milliontrees.egg-info/top_level.txt -> milliontrees-0.1.0/src/milliontrees.egg-info
copying src/milliontrees/common/__init__.py -> milliontrees-0.1.0/src/milliontrees/common
copying src/milliontrees/common/data_loaders.py -> milliontrees-0.1.0/src/milliontrees/common
copying src/milliontrees/common/grouper.py -> milliontrees-0.1.0/src/milliontrees/common
copying src/milliontrees/common/utils.py -> milliontrees-0.1.0/src/milliontrees/common
copying src/milliontrees/common/metrics/__init__.py -> milliontrees-0.1.0/src/milliontrees/common/metrics
copying src/milliontrees/common/metrics/all_metrics.py -> milliontrees-0.1.0/src/milliontrees/common/metrics
copying src/milliontrees/common/metrics/loss.py -> milliontrees-0.1.0/src/milliontrees/common/metrics
copying src/milliontrees/common/metrics/metric.py -> milliontrees-0.1.0/src/milliontrees/common/metrics
copying src/milliontrees/datasets/TreeBoxes.py -> milliontrees-0.1.0/src/milliontrees/datasets
copying src/milliontrees/datasets/TreePoints.py -> milliontrees-0.1.0/src/milliontrees/datasets
copying src/milliontrees/datasets/TreePolygons.py -> milliontrees-0.1.0/src/milliontrees/datasets
copying src/milliontrees/datasets/__init__.py -> milliontrees-0.1.0/src/milliontrees/datasets
copying src/milliontrees/datasets/download_utils.py -> milliontrees-0.1.0/src/milliontrees/datasets
copying src/milliontrees/datasets/milliontrees_dataset.py -> milliontrees-0.1.0/src/milliontrees/datasets
copying weights/DeepForest.py -> milliontrees-0.1.0/weights
copying weights/deepforest_config.yml -> milliontrees-0.1.0/weights
copying src/milliontrees.egg-info/SOURCES.txt -> milliontrees-0.1.0/src/milliontrees.egg-info
Writing milliontrees-0.1.0/setup.cfg
Creating tar archive
removing 'milliontrees-0.1.0' (and everything under it)
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools-scm[toml]>=6.2.3
  - setuptools>=61
* Getting build dependencies for wheel...
running egg_info
writing src/milliontrees.egg-info/PKG-INFO
writing dependency_links to src/milliontrees.egg-info/dependency_links.txt
writing requirements to src/milliontrees.egg-info/requires.txt
writing top-level names to src/milliontrees.egg-info/top_level.txt
ERROR setuptools_scm._file_finders.git listing git files failed - pretending there aren't any
reading manifest file 'src/milliontrees.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[cod]' found under directory '*'
warning: no previously-included files matching '*' found under directory 'tests'
warning: no previously-included files matching '*' found under directory 'docs'
warning: no previously-included files matching '*' found under directory 'data_prep'
adding license file 'LICENSE'
writing manifest file 'src/milliontrees.egg-info/SOURCES.txt'
* Building wheel...
running bdist_wheel
running build
running build_py
creating build/lib/milliontrees
copying src/milliontrees/get_dataset.py -> build/lib/milliontrees
copying src/milliontrees/version.py -> build/lib/milliontrees
copying src/milliontrees/__init__.py -> build/lib/milliontrees
copying src/milliontrees/download_datasets.py -> build/lib/milliontrees
creating build/lib/milliontrees/datasets
copying src/milliontrees/datasets/__init__.py -> build/lib/milliontrees/datasets
copying src/milliontrees/datasets/TreeBoxes.py -> build/lib/milliontrees/datasets
copying src/milliontrees/datasets/TreePoints.py -> build/lib/milliontrees/datasets
copying src/milliontrees/datasets/download_utils.py -> build/lib/milliontrees/datasets
copying src/milliontrees/datasets/milliontrees_dataset.py -> build/lib/milliontrees/datasets
copying src/milliontrees/datasets/TreePolygons.py -> build/lib/milliontrees/datasets
creating build/lib/milliontrees/common
copying src/milliontrees/common/__init__.py -> build/lib/milliontrees/common
copying src/milliontrees/common/data_loaders.py -> build/lib/milliontrees/common
copying src/milliontrees/common/utils.py -> build/lib/milliontrees/common
copying src/milliontrees/common/grouper.py -> build/lib/milliontrees/common
creating build/lib/milliontrees/common/metrics
copying src/milliontrees/common/metrics/all_metrics.py -> build/lib/milliontrees/common/metrics
copying src/milliontrees/common/metrics/__init__.py -> build/lib/milliontrees/common/metrics
copying src/milliontrees/common/metrics/metric.py -> build/lib/milliontrees/common/metrics
copying src/milliontrees/common/metrics/loss.py -> build/lib/milliontrees/common/metrics
running egg_info
writing src/milliontrees.egg-info/PKG-INFO
writing dependency_links to src/milliontrees.egg-info/dependency_links.txt
writing requirements to src/milliontrees.egg-info/requires.txt
writing top-level names to src/milliontrees.egg-info/top_level.txt
ERROR setuptools_scm._file_finders.git listing git files failed - pretending there aren't any
reading manifest file 'src/milliontrees.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[cod]' found under directory '*'
warning: no previously-included files matching '*' found under directory 'tests'
warning: no previously-included files matching '*' found under directory 'docs'
warning: no previously-included files matching '*' found under directory 'data_prep'
adding license file 'LICENSE'
writing manifest file 'src/milliontrees.egg-info/SOURCES.txt'
installing to build/bdist.macosx-10.15-x86_64/wheel
running install
running install_lib
creating build/bdist.macosx-10.15-x86_64/wheel
creating build/bdist.macosx-10.15-x86_64/wheel/milliontrees
copying build/lib/milliontrees/get_dataset.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees
copying build/lib/milliontrees/version.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees
creating build/bdist.macosx-10.15-x86_64/wheel/milliontrees/datasets
copying build/lib/milliontrees/datasets/__init__.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/datasets
copying build/lib/milliontrees/datasets/TreeBoxes.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/datasets
copying build/lib/milliontrees/datasets/TreePoints.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/datasets
copying build/lib/milliontrees/datasets/download_utils.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/datasets
copying build/lib/milliontrees/datasets/milliontrees_dataset.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/datasets
copying build/lib/milliontrees/datasets/TreePolygons.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/datasets
copying build/lib/milliontrees/__init__.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees
copying build/lib/milliontrees/download_datasets.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees
creating build/bdist.macosx-10.15-x86_64/wheel/milliontrees/common
creating build/bdist.macosx-10.15-x86_64/wheel/milliontrees/common/metrics
copying build/lib/milliontrees/common/metrics/all_metrics.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common/metrics
copying build/lib/milliontrees/common/metrics/__init__.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common/metrics
copying build/lib/milliontrees/common/metrics/metric.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common/metrics
copying build/lib/milliontrees/common/metrics/loss.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common/metrics
copying build/lib/milliontrees/common/__init__.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common
copying build/lib/milliontrees/common/data_loaders.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common
copying build/lib/milliontrees/common/utils.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common
copying build/lib/milliontrees/common/grouper.py -> build/bdist.macosx-10.15-x86_64/wheel/./milliontrees/common
running install_egg_info
Copying src/milliontrees.egg-info to build/bdist.macosx-10.15-x86_64/wheel/./milliontrees-0.1.0-py3.11.egg-info
running install_scripts
creating build/bdist.macosx-10.15-x86_64/wheel/milliontrees-0.1.0.dist-info/WHEEL
creating '/Users/benweinstein/Documents/MillionTrees/dist/.tmp-egpmt5d9/milliontrees-0.1.0-py3-none-any.whl' and adding 'build/bdist.macosx-10.15-x86_64/wheel' to it
adding 'milliontrees/__init__.py'
adding 'milliontrees/download_datasets.py'
adding 'milliontrees/get_dataset.py'
adding 'milliontrees/version.py'
adding 'milliontrees/common/__init__.py'
adding 'milliontrees/common/data_loaders.py'
adding 'milliontrees/common/grouper.py'
adding 'milliontrees/common/utils.py'
adding 'milliontrees/common/metrics/__init__.py'
adding 'milliontrees/common/metrics/all_metrics.py'
adding 'milliontrees/common/metrics/loss.py'
adding 'milliontrees/common/metrics/metric.py'
adding 'milliontrees/datasets/TreeBoxes.py'
adding 'milliontrees/datasets/TreePoints.py'
adding 'milliontrees/datasets/TreePolygons.py'
adding 'milliontrees/datasets/__init__.py'
adding 'milliontrees/datasets/download_utils.py'
adding 'milliontrees/datasets/milliontrees_dataset.py'
adding 'milliontrees-0.1.0.dist-info/LICENSE'
adding 'milliontrees-0.1.0.dist-info/METADATA'
adding 'milliontrees-0.1.0.dist-info/WHEEL'
adding 'milliontrees-0.1.0.dist-info/top_level.txt'
adding 'milliontrees-0.1.0.dist-info/RECORD'
removing build/bdist.macosx-10.15-x86_64/wheel
Successfully built milliontrees-0.1.0.tar.gz and milliontrees-0.1.0-py3-none-any.whl
```
package is nicely sized now

```
(MillionTrees) (base) benweinstein@Bens-MacBook-Pro MillionTrees % du -sh dist 
104K    dist
```