### PR TITLE
nesting the web dir to declutter the pub folder

### DIFF
--- a/src/milliontrees/datasets/TreeBoxes.py
+++ b/src/milliontrees/datasets/TreeBoxes.py
@@ -55,13 +55,13 @@ class TreeBoxesDataset(MillionTreesDataset):
         },
         "0.1": {
             'download_url':
-                "https://data.rc.ufl.edu/pub/ewhite/TreeBoxes_v0.1.zip",
+                "https://data.rc.ufl.edu/pub/ewhite/MillionTrees/TreeBoxes_v0.1.zip",
             'compressed_size':
                 3476300
         },
         "0.2": {
             'download_url':
-                "https://data.rc.ufl.edu/pub/ewhite/TreeBoxes_v0.2.zip",
+                "https://data.rc.ufl.edu/pub/ewhite/MillionTrees/TreeBoxes_v0.2.zip",
             'compressed_size':
                 6717977561
         }

--- a/src/milliontrees/datasets/TreePoints.py
+++ b/src/milliontrees/datasets/TreePoints.py
@@ -42,13 +42,13 @@ class TreePointsDataset(MillionTreesDataset):
         },
         "0.1": {
             'download_url':
-                "https://data.rc.ufl.edu/pub/ewhite/TreePoints_v0.1.zip",
+                "https://data.rc.ufl.edu/pub/ewhite/MillionTrees/TreePoints_v0.1.zip",
             'compressed_size':
                 170340
         },
         "0.2": {
             'download_url':
-                "https://data.rc.ufl.edu/pub/ewhite/TreePoints_v0.2.zip",
+                "https://data.rc.ufl.edu/pub/ewhite/MillionTrees/TreePoints_v0.2.zip",
             'compressed_size':
                 1459676926
         }

--- a/src/milliontrees/datasets/TreePolygons.py
+++ b/src/milliontrees/datasets/TreePolygons.py
@@ -51,13 +51,13 @@ class TreePolygonsDataset(MillionTreesDataset):
         },
         "0.1": {
             'download_url':
-                "https://data.rc.ufl.edu/pub/ewhite/TreePolygons_v0.1.zip",
+                "https://data.rc.ufl.edu/pub/ewhite/MillionTrees/TreePolygons_v0.1.zip",
             'compressed_size':
                 40277152
         },
         "0.2": {
             'download_url':
-                "https://data.rc.ufl.edu/pub/ewhite/TreePolygons_v0.2.zip",
+                "https://data.rc.ufl.edu/pub/ewhite/MillionTrees/TreePolygons_v0.2.zip",
             'compressed_size':
                 75419767345
         }


### PR DESCRIPTION
@ethanwhite asked me to move the releases one folder path down to make the pub dir more tidy. 