### PR TITLE
Add eval() visualization outputs and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,21 @@
 # To set up a development environment with all dependencies (including extras for development and testing),
 # use uv (https://github.com/astral-sh/uv):
 
-```python
-uv sync --dev extra
+```bash
+uv sync --extra dev
 uv run python
 ```
+
+## Pull requests
+
+CI runs [pre-commit](https://pre-commit.com/) hooks (YAPF and docformatter on `src/milliontrees/`). **Pull requests must pass `pre-commit` before merge**; fix style locally instead of relying on CI to fail.
+
+```bash
+uv sync --extra dev
+uv run pre-commit run --all-files
+```
+
+Use `uv run pre-commit install` once per clone if you want the same checks to run automatically on `git commit`. Equivalent manual commands are documented in `docs/contributing.md`.
 
 ## Coding Philosophy
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -30,7 +30,7 @@ After we work with an author to find a suitable data sharing agreement, we will 
 
 ## Code Style
 
-This project enforces consistent code style using [YAPF](https://github.com/google/yapf) and [docformatter](https://github.com/PyCQA/docformatter). Style is checked automatically in CI on every push and pull request.
+This project enforces consistent code style using [YAPF](https://github.com/google/yapf) and [docformatter](https://github.com/PyCQA/docformatter). Style is checked automatically in CI on every push and pull request. **Pull requests must pass these checks**; run `uv run pre-commit run --all-files` (see below) before opening or updating a PR so CI does not fail on formatting.
 
 ### Pre-commit hooks
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -41,6 +41,42 @@ print(results_str)
 
 The evaluation returns a dictionary of metrics and a formatted string with per-source breakdowns and averages.
 
+## Evaluation visualizations
+
+For qualitative debugging, pass **`viz_dir`** and optionally **`viz_n_per_source`** (default `4`) to `eval()`. The library writes PNGs under `viz_dir`, grouped in subfolders by source name, with up to `viz_n_per_source` images per source (in dataloader order).
+
+- **Purple**: ground-truth geometry (boxes, points, or mask fill).
+- **Orange**: predictions with `scores` above the dataset’s eval score threshold (same rule as metrics).
+
+Images are resized to the dataset’s eval `image_size` so coordinates match `y_pred` and `y_true` from `get_eval_loader`.
+
+When `viz_dir` is set, **`results["eval_visualization_paths"]`** lists the written PNG paths (strings).
+
+```python
+results, results_str = dataset.eval(
+    all_y_pred,
+    all_y_true,
+    metadata=test_dataset.metadata_array[: len(all_y_pred)],
+    viz_dir="work/eval_viz",
+    viz_n_per_source=3,
+)
+```
+
+### Example overlay (TreeBoxes + DeepForest)
+
+Below: one TreeBoxes test image from the onboarding split, ground-truth boxes in purple, and boxes from the pretrained **`weecology/deepforest-tree`** model in orange (same resize as eval).
+
+![TreeBoxes evaluation overlay: purple ground truth, orange DeepForest predictions](public/eval_visualization_sample.png)
+
+To regenerate this image after changing overlay styles or the sample batch, install dev extras and run:
+
+```bash
+uv sync --dev
+uv run python docs/scripts/generate_eval_viz_sample.py --root-dir onboarding_data
+```
+
+The script uses **`include_unsupervised=True`** so a local tree layout such as `onboarding_data/TreeBoxes_v0.12/` is found (the default supervised-only layout uses a different directory name). Use **`--mini --download`** only if you rely on the mini zip URL instead.
+
 ## External Model Adapter Example (Segmentation / DeepTrees-style)
 
 If your model outputs instance masks (for example, a segmentation model such as DeepTrees), use the adapter example:

--- a/docs/public/eval_visualization_sample.png
+++ b/docs/public/eval_visualization_sample.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3f143f8d15e029edf1cd2a16a95e37164a3e3b9d630bd2e4df26e6a3466ca7c
+size 373047

--- a/docs/scripts/generate_eval_viz_sample.py
+++ b/docs/scripts/generate_eval_viz_sample.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Regenerate docs/public/eval_visualization_sample.png using DeepForest + mini TreeBoxes.
+
+Requires optional dev dependencies (``deepforest``). From the repo root::
+
+    uv sync --dev
+    uv run python docs/scripts/generate_eval_viz_sample.py --root-dir onboarding_data
+
+Uses one eval batch, runs ``dataset.eval(..., viz_dir=...)``, then copies the first
+written overlay PNG to ``docs/public/eval_visualization_sample.png``.
+
+``include_unsupervised=True`` is set so ``onboarding_data/TreeBoxes_v0.12`` is used
+instead of the ``TreeBoxes_supervised_v*`` directory name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import tempfile
+import warnings
+from pathlib import Path
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT = REPO_ROOT / "docs" / "public" / "eval_visualization_sample.png"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root-dir",
+        type=str,
+        default="onboarding_data",
+        help="MillionTrees data root (directory that contains TreeBoxes_v*).",
+    )
+    parser.add_argument(
+        "--mini",
+        action="store_true",
+        help="Use mini TreeBoxes URLs (requires working download host).",
+    )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download dataset archive if the version folder is missing.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help="Output PNG path.",
+    )
+    args = parser.parse_args()
+
+    try:
+        from deepforest import main as df_main
+        from deepforest.utilities import format_geometry
+    except ImportError as e:
+        raise SystemExit(
+            "deepforest is required. Install dev extras: uv sync --dev"
+        ) from e
+
+    from milliontrees import get_dataset
+    from milliontrees.common.data_loaders import get_eval_loader
+
+    warnings.filterwarnings("ignore")
+    model = df_main.deepforest()
+    model.load_model("weecology/deepforest-tree")
+    model.eval()
+
+    # Use full dataset folder name ``TreeBoxes_v*`` (matches repo ``onboarding_data``), not
+    # ``TreeBoxes_supervised_v*`` used when include_unsupervised is False.
+    dataset = get_dataset(
+        "TreeBoxes",
+        root_dir=args.root_dir,
+        download=args.download,
+        mini=args.mini,
+        split_scheme="random",
+        include_unsupervised=True,
+    )
+    test_subset = dataset.get_subset("test")
+    test_loader = get_eval_loader("standard", test_subset, batch_size=4, num_workers=0)
+
+    metadata, images, targets = next(iter(test_loader))
+    predictions = model.predict_step(images, 0)
+
+    all_y_pred, all_y_true = [], []
+    for image_metadata, pred, target in zip(metadata, predictions, targets):
+        if pred is None or len(pred["boxes"]) == 0:
+            all_y_pred.append(
+                {
+                    "y": torch.zeros((0, 4), dtype=torch.float32),
+                    "labels": torch.zeros((0,), dtype=torch.int64),
+                    "scores": torch.zeros((0,), dtype=torch.float32),
+                }
+            )
+        else:
+            df = format_geometry(pred)
+            all_y_pred.append(
+                {
+                    "y": torch.tensor(
+                        df[["xmin", "ymin", "xmax", "ymax"]].values.astype("float32")
+                    ),
+                    "labels": torch.tensor(df.label.values.astype("int64")),
+                    "scores": torch.tensor(df.score.values.astype("float32")),
+                }
+            )
+        all_y_true.append(target)
+
+    used_meta = test_subset.metadata_array[: len(all_y_true)]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        _, _ = dataset.eval(
+            all_y_pred,
+            all_y_true,
+            used_meta,
+            viz_dir=str(tmp_path),
+            viz_n_per_source=4,
+        )
+        pngs = sorted(tmp_path.rglob("*.png"))
+        if not pngs:
+            raise SystemExit("No visualization PNGs were written; check dataset / preds.")
+
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(pngs[0], args.out)
+        print(f"Wrote {args.out} (from {pngs[0].relative_to(tmp_path)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/milliontrees/common/eval_visualization.py
+++ b/src/milliontrees/common/eval_visualization.py
@@ -44,7 +44,8 @@ def _resize_eval_image(img_hwc: np.ndarray, size: int) -> np.ndarray:
 def _tensor_boxes(geo, name: str) -> np.ndarray:
     if geo is None:
         return np.zeros((0, 4), dtype=np.float32)
-    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(geo, dtype=torch.float32)
+    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(
+        geo, dtype=torch.float32)
     t = t.detach().cpu().float()
     if t.numel() == 0:
         return np.zeros((0, 4), dtype=np.float32)
@@ -54,7 +55,8 @@ def _tensor_boxes(geo, name: str) -> np.ndarray:
 
 
 def _tensor_points(geo) -> np.ndarray:
-    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(geo, dtype=torch.float32)
+    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(
+        geo, dtype=torch.float32)
     t = t.detach().cpu().float()
     if t.numel() == 0:
         return np.zeros((0, 2), dtype=np.float32)
@@ -70,7 +72,8 @@ def _tensor_masks(geo, empty_hw: int) -> np.ndarray:
     t = t.detach().cpu()
     if t.numel() == 0:
         if t.ndim == 3 and t.shape[1] > 0 and t.shape[2] > 0:
-            return np.zeros((0, int(t.shape[1]), int(t.shape[2])), dtype=np.uint8)
+            return np.zeros((0, int(t.shape[1]), int(t.shape[2])),
+                            dtype=np.uint8)
         return np.zeros((0, empty_hw, empty_hw), dtype=np.uint8)
     arr = t.numpy()
     if arr.ndim == 2:
@@ -143,8 +146,7 @@ def save_eval_visualizations(
     if len(y_pred) != len(y_true) or len(y_pred) != len(metadata):
         raise ValueError(
             "y_pred, y_true, and metadata must have the same length "
-            f"({len(y_pred)}, {len(y_true)}, {len(metadata)})."
-        )
+            f"({len(y_pred)}, {len(y_true)}, {len(metadata)}).")
 
     if not isinstance(metadata, torch.Tensor):
         metadata = torch.as_tensor(metadata)
@@ -166,7 +168,8 @@ def save_eval_visualizations(
 
         filename_id = int(metadata[row, 0].item())
         if filename_id not in fid_to_idx:
-            raise KeyError(f"filename_id {filename_id} not found in dataset metadata.")
+            raise KeyError(
+                f"filename_id {filename_id} not found in dataset metadata.")
         ds_idx = fid_to_idx[filename_id]
 
         raw = _to_numpy_image(dataset.get_input(ds_idx))
@@ -183,9 +186,9 @@ def save_eval_visualizations(
             if scores is None:
                 pred_boxes = _tensor_boxes(pr.get(geom), geom)
             else:
-                sc = scores if isinstance(scores, torch.Tensor) else torch.as_tensor(
-                    scores, dtype=torch.float32
-                )
+                sc = scores if isinstance(scores,
+                                          torch.Tensor) else torch.as_tensor(
+                                              scores, dtype=torch.float32)
                 sc = sc.detach().cpu().float()
                 geo = pr.get(geom)
                 pb = _tensor_boxes(geo, geom)
@@ -201,13 +204,14 @@ def save_eval_visualizations(
             gt_pts = _tensor_points(gt.get(geom))
             scores = pr.get("scores")
             geo = pr.get(geom)
-            pp = _tensor_points(geo) if geo is not None else np.zeros((0, 2), dtype=np.float32)
+            pp = _tensor_points(geo) if geo is not None else np.zeros(
+                (0, 2), dtype=np.float32)
             if scores is None or len(pp) == 0:
                 pred_pts = pp
             else:
-                sc = scores if isinstance(scores, torch.Tensor) else torch.as_tensor(
-                    scores, dtype=torch.float32
-                )
+                sc = scores if isinstance(scores,
+                                          torch.Tensor) else torch.as_tensor(
+                                              scores, dtype=torch.float32)
                 sc = sc.detach().cpu().float().numpy()
                 keep = sc > score_threshold
                 pred_pts = pp[keep]
@@ -220,9 +224,9 @@ def save_eval_visualizations(
             geo = pr.get(geom)
             pm = _tensor_masks(geo, image_size)
             if scores is not None and pm.shape[0] > 0:
-                sc = scores if isinstance(scores, torch.Tensor) else torch.as_tensor(
-                    scores, dtype=torch.float32
-                )
+                sc = scores if isinstance(scores,
+                                          torch.Tensor) else torch.as_tensor(
+                                              scores, dtype=torch.float32)
                 sc = sc.detach().cpu().float().numpy()
                 pm = pm[sc > score_threshold]
             arr = np.asarray(base, dtype=np.uint8)
@@ -230,10 +234,14 @@ def save_eval_visualizations(
             arr = _blend_masks(arr, pm, _COLOR_PREDICTION, alpha=0.35)
             base = Image.fromarray(arr, mode="RGB")
         else:
-            raise ValueError(f"Unsupported dataset for eval visualization: {task}")
+            raise ValueError(
+                f"Unsupported dataset for eval visualization: {task}")
 
-        src_name = getattr(dataset, "_source_id_to_code", {}).get(source_id, str(source_id))
-        stem = Path(getattr(dataset, "_filename_id_to_code", {}).get(filename_id, f"id_{filename_id}")).stem
+        src_name = getattr(dataset, "_source_id_to_code",
+                           {}).get(source_id, str(source_id))
+        stem = Path(
+            getattr(dataset, "_filename_id_to_code",
+                    {}).get(filename_id, f"id_{filename_id}")).stem
         sub = out_path / _slug(src_name)
         sub.mkdir(parents=True, exist_ok=True)
         k = per_source_count.get(source_id, 0)

--- a/src/milliontrees/common/eval_visualization.py
+++ b/src/milliontrees/common/eval_visualization.py
@@ -1,0 +1,245 @@
+"""Save qualitative evaluation images (ground truth vs predictions) per source."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image, ImageDraw
+
+# GT vs prediction overlay colors (RGB)
+_COLOR_GROUND_TRUTH = (128, 60, 200)  # purple
+_COLOR_PREDICTION = (255, 140, 0)  # orange
+
+
+def _slug(name: str, max_len: int = 80) -> str:
+    s = re.sub(r"[^\w.\-]+", "_", str(name), flags=re.UNICODE).strip("_")
+    return s[:max_len] if len(s) > max_len else s or "source"
+
+
+def _filename_id_to_index(dataset) -> dict[int, int]:
+    ma = dataset.metadata_array
+    if not isinstance(ma, torch.Tensor):
+        ma = torch.as_tensor(ma)
+    return {int(ma[i, 0].item()): i for i in range(ma.shape[0])}
+
+
+def _to_numpy_image(x: np.ndarray | torch.Tensor) -> np.ndarray:
+    if isinstance(x, torch.Tensor):
+        x = x.detach().cpu().numpy()
+    if x.ndim == 3 and x.shape[0] in (1, 3) and x.shape[0] < x.shape[-1]:
+        x = np.transpose(x, (1, 2, 0))
+    return np.clip(x.astype(np.float32), 0.0, 1.0)
+
+
+def _resize_eval_image(img_hwc: np.ndarray, size: int) -> np.ndarray:
+    u8 = (np.clip(img_hwc, 0.0, 1.0) * 255.0).round().astype(np.uint8)
+    pil = Image.fromarray(u8, mode="RGB")
+    pil = pil.resize((size, size), Image.Resampling.BILINEAR)
+    return np.asarray(pil, dtype=np.uint8)
+
+
+def _tensor_boxes(geo, name: str) -> np.ndarray:
+    if geo is None:
+        return np.zeros((0, 4), dtype=np.float32)
+    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(geo, dtype=torch.float32)
+    t = t.detach().cpu().float()
+    if t.numel() == 0:
+        return np.zeros((0, 4), dtype=np.float32)
+    if t.dim() == 1:
+        t = t.view(-1, 4)
+    return t.numpy()
+
+
+def _tensor_points(geo) -> np.ndarray:
+    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(geo, dtype=torch.float32)
+    t = t.detach().cpu().float()
+    if t.numel() == 0:
+        return np.zeros((0, 2), dtype=np.float32)
+    if t.dim() == 1:
+        t = t.view(-1, 2)
+    return t.numpy()
+
+
+def _tensor_masks(geo, empty_hw: int) -> np.ndarray:
+    if geo is None:
+        return np.zeros((0, empty_hw, empty_hw), dtype=np.uint8)
+    t = geo if isinstance(geo, torch.Tensor) else torch.as_tensor(geo)
+    t = t.detach().cpu()
+    if t.numel() == 0:
+        if t.ndim == 3 and t.shape[1] > 0 and t.shape[2] > 0:
+            return np.zeros((0, int(t.shape[1]), int(t.shape[2])), dtype=np.uint8)
+        return np.zeros((0, empty_hw, empty_hw), dtype=np.uint8)
+    arr = t.numpy()
+    if arr.ndim == 2:
+        arr = arr[np.newaxis, ...]
+    return (arr > 0).astype(np.uint8)
+
+
+def _draw_boxes(
+    draw: ImageDraw.ImageDraw,
+    boxes: np.ndarray,
+    color: tuple[int, int, int],
+    width: int = 2,
+) -> None:
+    for b in boxes:
+        x1, y1, x2, y2 = [float(x) for x in b]
+        draw.rectangle([x1, y1, x2, y2], outline=color, width=width)
+
+
+def _draw_points(
+    draw: ImageDraw.ImageDraw,
+    pts: np.ndarray,
+    color: tuple[int, int, int],
+    r: int = 4,
+) -> None:
+    for p in pts:
+        x, y = float(p[0]), float(p[1])
+        draw.ellipse([x - r, y - r, x + r, y + r], outline=color, width=2)
+
+
+def _blend_masks(
+    base_rgb: np.ndarray,
+    masks: np.ndarray,
+    color: tuple[int, int, int],
+    alpha: float = 0.35,
+) -> np.ndarray:
+    out = base_rgb.astype(np.float32)
+    for i in range(masks.shape[0]):
+        m = masks[i].astype(bool)
+        if not m.any():
+            continue
+        for c in range(3):
+            ch = out[:, :, c]
+            ch[m] = ch[m] * (1.0 - alpha) + float(color[c]) * alpha
+            out[:, :, c] = ch
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def save_eval_visualizations(
+    dataset,
+    y_pred: list[dict],
+    y_true: list[dict],
+    metadata: torch.Tensor,
+    out_dir: str | Path,
+    *,
+    n_per_source: int = 4,
+    score_threshold: float | None = None,
+) -> list[Path]:
+    """Write up to ``n_per_source`` images per ``source_id`` with GT and predictions overlaid.
+
+    Ground truth is drawn in purple; predictions above ``score_threshold`` are orange.
+
+    Images are resized to ``dataset.image_size`` so coordinates match ``y_pred`` / ``y_true``
+    from the standard eval loader.
+
+    Returns paths of written PNG files.
+    """
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    if len(y_pred) != len(y_true) or len(y_pred) != len(metadata):
+        raise ValueError(
+            "y_pred, y_true, and metadata must have the same length "
+            f"({len(y_pred)}, {len(y_true)}, {len(metadata)})."
+        )
+
+    if not isinstance(metadata, torch.Tensor):
+        metadata = torch.as_tensor(metadata)
+
+    fid_to_idx = _filename_id_to_index(dataset)
+    geom = dataset.geometry_name
+    task = dataset._dataset_name
+    image_size = int(getattr(dataset, "image_size", 448))
+    if score_threshold is None:
+        score_threshold = float(getattr(dataset, "eval_score_threshold", 0.1))
+
+    per_source_count: dict[int, int] = {}
+    written: list[Path] = []
+
+    for row in range(len(y_pred)):
+        source_id = int(metadata[row, 1].item())
+        if per_source_count.get(source_id, 0) >= n_per_source:
+            continue
+
+        filename_id = int(metadata[row, 0].item())
+        if filename_id not in fid_to_idx:
+            raise KeyError(f"filename_id {filename_id} not found in dataset metadata.")
+        ds_idx = fid_to_idx[filename_id]
+
+        raw = _to_numpy_image(dataset.get_input(ds_idx))
+        rgb = _resize_eval_image(raw, image_size)
+        base = Image.fromarray(rgb, mode="RGB")
+        draw = ImageDraw.Draw(base)
+
+        gt = y_true[row]
+        pr = y_pred[row]
+
+        if task == "TreeBoxes":
+            gt_boxes = _tensor_boxes(gt.get(geom), geom)
+            scores = pr.get("scores")
+            if scores is None:
+                pred_boxes = _tensor_boxes(pr.get(geom), geom)
+            else:
+                sc = scores if isinstance(scores, torch.Tensor) else torch.as_tensor(
+                    scores, dtype=torch.float32
+                )
+                sc = sc.detach().cpu().float()
+                geo = pr.get(geom)
+                pb = _tensor_boxes(geo, geom)
+                if len(pb) == 0:
+                    pred_boxes = pb
+                else:
+                    keep = sc.numpy() > score_threshold
+                    pred_boxes = pb[keep]
+            _draw_boxes(draw, gt_boxes, _COLOR_GROUND_TRUTH, width=3)
+            _draw_boxes(draw, pred_boxes, _COLOR_PREDICTION, width=2)
+
+        elif task == "TreePoints":
+            gt_pts = _tensor_points(gt.get(geom))
+            scores = pr.get("scores")
+            geo = pr.get(geom)
+            pp = _tensor_points(geo) if geo is not None else np.zeros((0, 2), dtype=np.float32)
+            if scores is None or len(pp) == 0:
+                pred_pts = pp
+            else:
+                sc = scores if isinstance(scores, torch.Tensor) else torch.as_tensor(
+                    scores, dtype=torch.float32
+                )
+                sc = sc.detach().cpu().float().numpy()
+                keep = sc > score_threshold
+                pred_pts = pp[keep]
+            _draw_points(draw, gt_pts, _COLOR_GROUND_TRUTH, r=5)
+            _draw_points(draw, pred_pts, _COLOR_PREDICTION, r=4)
+
+        elif task == "TreePolygons":
+            gt_m = _tensor_masks(gt.get(geom), image_size)
+            scores = pr.get("scores")
+            geo = pr.get(geom)
+            pm = _tensor_masks(geo, image_size)
+            if scores is not None and pm.shape[0] > 0:
+                sc = scores if isinstance(scores, torch.Tensor) else torch.as_tensor(
+                    scores, dtype=torch.float32
+                )
+                sc = sc.detach().cpu().float().numpy()
+                pm = pm[sc > score_threshold]
+            arr = np.asarray(base, dtype=np.uint8)
+            arr = _blend_masks(arr, gt_m, _COLOR_GROUND_TRUTH, alpha=0.35)
+            arr = _blend_masks(arr, pm, _COLOR_PREDICTION, alpha=0.35)
+            base = Image.fromarray(arr, mode="RGB")
+        else:
+            raise ValueError(f"Unsupported dataset for eval visualization: {task}")
+
+        src_name = getattr(dataset, "_source_id_to_code", {}).get(source_id, str(source_id))
+        stem = Path(getattr(dataset, "_filename_id_to_code", {}).get(filename_id, f"id_{filename_id}")).stem
+        sub = out_path / _slug(src_name)
+        sub.mkdir(parents=True, exist_ok=True)
+        k = per_source_count.get(source_id, 0)
+        fname = sub / f"{k:03d}_{_slug(stem)}.png"
+        base.save(fname)
+        written.append(fname)
+        per_source_count[source_id] = k + 1
+
+    return written

--- a/src/milliontrees/datasets/TreeBoxes.py
+++ b/src/milliontrees/datasets/TreeBoxes.py
@@ -11,6 +11,7 @@ import torchvision.transforms as T
 import fnmatch
 
 from milliontrees.datasets.milliontrees_dataset import MillionTreesDataset
+from milliontrees.common.eval_visualization import save_eval_visualizations
 from milliontrees.common.grouper import CombinatorialGrouper
 from milliontrees.common.metrics.all_metrics import DetectionAccuracy, DetectionMAP
 from milliontrees.common.onboarding import print_dataset_summary
@@ -281,11 +282,15 @@ class TreeBoxesDataset(MillionTreesDataset):
 
         super().__init__(root_dir, download, split_scheme)
 
-    def eval(self, y_pred, y_true, metadata):
+    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
         """Performs evaluation on the given predictions.
 
         The main evaluation metric, detection_acc_avg_dom, measures the simple average of the
         detection accuracies of each domain.
+
+        If ``viz_dir`` is set, writes overlay PNGs (purple = ground truth, orange = predictions above
+        the eval score threshold), up to ``viz_n_per_source`` images per source, in subfolders
+        named by source.
         """
 
         results = {}
@@ -312,6 +317,18 @@ class TreeBoxesDataset(MillionTreesDataset):
         from milliontrees.common.utils import format_eval_results
         formatted_results = format_eval_results(results, self)
         results_str = formatted_results + '\n' + results_str
+
+        if viz_dir is not None:
+            paths = save_eval_visualizations(
+                self,
+                y_pred,
+                y_true,
+                metadata,
+                viz_dir,
+                n_per_source=viz_n_per_source,
+                score_threshold=self.eval_score_threshold,
+            )
+            results["eval_visualization_paths"] = [str(p) for p in paths]
 
         return results, results_str
 

--- a/src/milliontrees/datasets/TreeBoxes.py
+++ b/src/milliontrees/datasets/TreeBoxes.py
@@ -282,7 +282,13 @@ class TreeBoxesDataset(MillionTreesDataset):
 
         super().__init__(root_dir, download, split_scheme)
 
-    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
+    def eval(self,
+             y_pred,
+             y_true,
+             metadata,
+             *,
+             viz_dir=None,
+             viz_n_per_source=4):
         """Performs evaluation on the given predictions.
 
         The main evaluation metric, detection_acc_avg_dom, measures the simple average of the

--- a/src/milliontrees/datasets/TreePoints.py
+++ b/src/milliontrees/datasets/TreePoints.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 
 from milliontrees.datasets.milliontrees_dataset import MillionTreesDataset
+from milliontrees.common.eval_visualization import save_eval_visualizations
 from milliontrees.common.grouper import CombinatorialGrouper
 from milliontrees.common.metrics.all_metrics import KeypointAccuracy, CountingError
 from milliontrees.common.utils import format_eval_results
@@ -260,9 +261,12 @@ class TreePointsDataset(MillionTreesDataset):
         indices = self._input_lookup[filename]
         return self._y_array[indices]
 
-    def eval(self, y_pred, y_true, metadata):
+    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
         """The main evaluation metric, detection_acc_avg_dom, measures the simple average of the
-        detection accuracies of each domain."""
+        detection accuracies of each domain.
+
+        Optional ``viz_dir`` / ``viz_n_per_source`` write qualitative overlays (see TreeBoxes.eval).
+        """
 
         results = {}
         results_str = ''
@@ -290,6 +294,18 @@ class TreePointsDataset(MillionTreesDataset):
         # Format results with tables
         formatted_results = format_eval_results(results, self)
         results_str = formatted_results + '\n' + results_str
+
+        if viz_dir is not None:
+            paths = save_eval_visualizations(
+                self,
+                y_pred,
+                y_true,
+                metadata,
+                viz_dir,
+                n_per_source=viz_n_per_source,
+                score_threshold=self.metrics["KeypointAccuracy"].score_threshold,
+            )
+            results["eval_visualization_paths"] = [str(p) for p in paths]
 
         return results, results_str
 

--- a/src/milliontrees/datasets/TreePoints.py
+++ b/src/milliontrees/datasets/TreePoints.py
@@ -261,7 +261,13 @@ class TreePointsDataset(MillionTreesDataset):
         indices = self._input_lookup[filename]
         return self._y_array[indices]
 
-    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
+    def eval(self,
+             y_pred,
+             y_true,
+             metadata,
+             *,
+             viz_dir=None,
+             viz_n_per_source=4):
         """The main evaluation metric, detection_acc_avg_dom, measures the simple average of the
         detection accuracies of each domain.
 
@@ -303,7 +309,8 @@ class TreePointsDataset(MillionTreesDataset):
                 metadata,
                 viz_dir,
                 n_per_source=viz_n_per_source,
-                score_threshold=self.metrics["KeypointAccuracy"].score_threshold,
+                score_threshold=self.metrics["KeypointAccuracy"].
+                score_threshold,
             )
             results["eval_visualization_paths"] = [str(p) for p in paths]
 

--- a/src/milliontrees/datasets/TreePolygons.py
+++ b/src/milliontrees/datasets/TreePolygons.py
@@ -365,7 +365,13 @@ class TreePolygonsDataset(MillionTreesDataset):
 
         return mask_img
 
-    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
+    def eval(self,
+             y_pred,
+             y_true,
+             metadata,
+             *,
+             viz_dir=None,
+             viz_n_per_source=4):
         """The main evaluation metric, detection_acc_avg_dom, measures the simple average of the
         detection accuracies of each domain.
 

--- a/src/milliontrees/datasets/TreePolygons.py
+++ b/src/milliontrees/datasets/TreePolygons.py
@@ -13,6 +13,7 @@ from torchvision.tv_tensors import BoundingBoxes, Mask
 from torchvision.ops import masks_to_boxes
 
 from milliontrees.datasets.milliontrees_dataset import MillionTreesDataset
+from milliontrees.common.eval_visualization import save_eval_visualizations
 from milliontrees.common.grouper import CombinatorialGrouper
 from milliontrees.common.metrics.all_metrics import MaskAccuracy, DetectionMAP
 from milliontrees.common.onboarding import print_dataset_summary
@@ -364,9 +365,13 @@ class TreePolygonsDataset(MillionTreesDataset):
 
         return mask_img
 
-    def eval(self, y_pred, y_true, metadata):
+    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
         """The main evaluation metric, detection_acc_avg_dom, measures the simple average of the
-        detection accuracies of each domain."""
+        detection accuracies of each domain.
+
+        Optional ``viz_dir`` / ``viz_n_per_source`` write qualitative overlays (purple = GT masks,
+        orange = predicted masks above the eval score threshold).
+        """
 
         results = {}
         results_str = ''
@@ -392,6 +397,18 @@ class TreePolygonsDataset(MillionTreesDataset):
         from milliontrees.common.utils import format_eval_results
         formatted_results = format_eval_results(results, self)
         results_str = formatted_results + '\n' + results_str
+
+        if viz_dir is not None:
+            paths = save_eval_visualizations(
+                self,
+                y_pred,
+                y_true,
+                metadata,
+                viz_dir,
+                n_per_source=viz_n_per_source,
+                score_threshold=self.eval_score_threshold,
+            )
+            results["eval_visualization_paths"] = [str(p) for p in paths]
 
         return results, results_str
 

--- a/src/milliontrees/datasets/milliontrees_dataset.py
+++ b/src/milliontrees/datasets/milliontrees_dataset.py
@@ -82,14 +82,18 @@ class MillionTreesDataset:
             )
         return mask
 
-    def eval(self, y_pred, y_true, metadata):
+    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
         """
         Args:
-            - y_pred (Tensor): Predicted targets
-            - y_true (Tensor): True targets
-            - metadata (Tensor): Metadata
+            - y_pred (list[dict]): Predicted targets per image
+            - y_true (list[dict]): True targets per image
+            - metadata (Tensor): Metadata rows aligned with predictions
+            - viz_dir (str | Path | None): If set, write up to ``viz_n_per_source`` overlay
+              PNGs per ``source_id`` under this directory (see ``eval_visualization``).
+            - viz_n_per_source (int): Max images to save per source when ``viz_dir`` is set.
+
         Output:
-            - results (dict): Dictionary of results
+            - results (dict): Dictionary of results (may include ``eval_visualization_paths``)
             - results_str (str): Pretty print version of the results
         """
         raise NotImplementedError
@@ -664,5 +668,11 @@ class MillionTreesSubset(MillionTreesDataset):
     def metadata_array(self):
         return torch.tensor(self.dataset.metadata_array[self.indices])
 
-    def eval(self, y_pred, y_true, metadata):
-        return self.dataset.eval(y_pred, y_true, metadata)
+    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
+        return self.dataset.eval(
+            y_pred,
+            y_true,
+            metadata,
+            viz_dir=viz_dir,
+            viz_n_per_source=viz_n_per_source,
+        )

--- a/src/milliontrees/datasets/milliontrees_dataset.py
+++ b/src/milliontrees/datasets/milliontrees_dataset.py
@@ -82,7 +82,13 @@ class MillionTreesDataset:
             )
         return mask
 
-    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
+    def eval(self,
+             y_pred,
+             y_true,
+             metadata,
+             *,
+             viz_dir=None,
+             viz_n_per_source=4):
         """
         Args:
             - y_pred (list[dict]): Predicted targets per image
@@ -668,7 +674,13 @@ class MillionTreesSubset(MillionTreesDataset):
     def metadata_array(self):
         return torch.tensor(self.dataset.metadata_array[self.indices])
 
-    def eval(self, y_pred, y_true, metadata, *, viz_dir=None, viz_n_per_source=4):
+    def eval(self,
+             y_pred,
+             y_true,
+             metadata,
+             *,
+             viz_dir=None,
+             viz_n_per_source=4):
         return self.dataset.eval(
             y_pred,
             y_true,

--- a/tests/test_TreeBoxes.py
+++ b/tests/test_TreeBoxes.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from milliontrees.datasets.TreeBoxes import TreeBoxesDataset
 from milliontrees.common.data_loaders import get_train_loader, get_eval_loader
 
@@ -130,6 +132,38 @@ def test_TreeBoxes_eval(dataset, pred_tensor):
     assert len(eval_results) 
     assert "accuracy" in eval_results.keys()
     assert "recall" in eval_results.keys()
+
+
+def test_TreeBoxes_eval_visualization(dataset, tmp_path):
+    ds = TreeBoxesDataset(download=False, root_dir=dataset, version="0.0")
+    test_dataset = ds.get_subset("test")
+    test_loader = get_eval_loader("standard", test_dataset, batch_size=2)
+    all_y_pred, all_y_true = [], []
+    pred_tensor = [[30, 70, 35, 75]]
+    for _, x, y_true in test_loader:
+        labels = torch.zeros(x.shape[0])
+        scores = torch.stack(
+            [torch.tensor(0.54) for _ in range(len(pred_tensor))])
+        y_pred = [{
+            "y": torch.tensor(pred_tensor),
+            "labels": labels,
+            "scores": scores,
+        } for _ in range(x.shape[0])]
+        all_y_true.extend(y_true)
+        all_y_pred.extend(y_pred)
+
+    viz_root = tmp_path / "viz"
+    out, _ = ds.eval(
+        y_pred=all_y_pred,
+        y_true=all_y_true,
+        metadata=test_dataset.metadata_array,
+        viz_dir=str(viz_root),
+        viz_n_per_source=2,
+    )
+    paths = out["eval_visualization_paths"]
+    assert len(paths) >= 1
+    for p in paths:
+        assert Path(p).is_file()
 
 
 def test_TreeBoxes_download_url(dataset):


### PR DESCRIPTION
Optional viz_dir and viz_n_per_source on dataset.eval() write per-source PNG overlays (purple ground truth, orange predictions) via save_eval_visualizations. Subset.eval forwards the same kwargs.

Adds docs/evaluation.md section, sample overlay from DeepForest on onboarding TreeBoxes, and docs/scripts/generate_eval_viz_sample.py to regenerate the asset. Includes test_TreeBoxes_eval_visualization.

Made-with: Cursor