### PR TITLE
Update leaderboard with latest training and model evaluation results

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -34,7 +34,7 @@ All point sources are used to train and predict all box sources.
 
 | Model | Fine-tuned | Counting MAE | Script |
 |---|:---:|---|---|
-| SAM3 | ✗ | 23.691 | <small>`uv run python docs/examples/sam3_points.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| SAM3 | ✗ | 13.552 | <small>`uv run python docs/examples/sam3_points.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
 | DeepForest | ✗ | 25.289 | <small>`uv run python docs/examples/baseline_points.py --split-scheme random`</small> |
 | DeepForest | ✓ | 25.757 | <small>`uv run python training/points/train.py --split-scheme random`</small> |
 
@@ -43,8 +43,8 @@ All point sources are used to train and predict all box sources.
 | Model | Fine-tuned | Counting MAE | Script |
 |---|:---:|---|---|
 | DeepForest | ✗ | 51.462 | <small>`uv run python docs/examples/baseline_points.py --split-scheme zeroshot`</small> |
-| SAM3 | ✗ | 55.043 | <small>`uv run python docs/examples/sam3_points.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 | DeepForest | ✓ | 57.818 | <small>`uv run python training/points/train.py --split-scheme zeroshot`</small> |
+| SAM3 | ✗ | 61.057 | <small>`uv run python docs/examples/sam3_points.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 
 ### Cross-geometry
 
@@ -63,16 +63,16 @@ All point sources are used to train and predict all box sources.
 
 | Model | Fine-tuned | Avg Recall | Script |
 |---|:---:|---|---|
-| DeepForest | ✓ | 0.752 | <small>`uv run python training/boxes/train_boxes.py --split-scheme random`</small> |
+| DeepForest | ✓ | 0.762 | <small>`uv run python training/boxes/train_boxes.py --split-scheme random`</small> |
 | DeepForest | ✗ | 0.559 | <small>`uv run python docs/examples/baseline_boxes.py --split-scheme random`</small> |
-| SAM3 | ✗ | 0.197 | <small>`uv run python docs/examples/sam3_boxes.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| SAM3 | ✗ | 0.185 | <small>`uv run python docs/examples/sam3_boxes.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
 
 ### Zero-shot
 
 | Model | Fine-tuned | Avg Recall | Script |
 |---|:---:|---|---|
-| DeepForest | ✓ | 0.548 | <small>`uv run python training/boxes/train_boxes.py --split-scheme zeroshot`</small> |
 | DeepForest | ✗ | 0.539 | <small>`uv run python docs/examples/baseline_boxes.py --split-scheme zeroshot`</small> |
+| DeepForest | ✓ | 0.496 | <small>`uv run python training/boxes/train_boxes.py --split-scheme zeroshot`</small> |
 | SAM3 | ✗ | 0.199 | <small>`uv run python docs/examples/sam3_boxes.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 
 ### Cross-geometry
@@ -93,15 +93,15 @@ All point sources are used to train and predict all box sources.
 | Model | Fine-tuned | Avg Mask Accuracy | Script |
 |---|:---:|---|---|
 | DeepForest | ✓ | 0.238 | <small>`uv run python training/polygons/train.py --split-scheme random`</small> |
-| SAM3 | ✗ | 0.167 | <small>`uv run python docs/examples/sam3_polygons.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| SAM3 | ✗ | 0.188 | <small>`uv run python docs/examples/sam3_polygons.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
 | DeepForest | ✗ | 0.090 | <small>`uv run python docs/examples/baseline_polygons.py --split-scheme random`</small> |
 
 ### Zero-shot
 
 | Model | Fine-tuned | Avg Mask Accuracy | Script |
 |---|:---:|---|---|
-| SAM3 | ✗ | 0.322 | <small>`uv run python docs/examples/sam3_polygons.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 | DeepForest | ✓ | 0.176 | <small>`uv run python training/polygons/train.py --split-scheme zeroshot`</small> |
+| SAM3 | ✗ | 0.165 | <small>`uv run python docs/examples/sam3_polygons.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 | DeepForest | ✗ | 0.071 | <small>`uv run python docs/examples/baseline_polygons.py --split-scheme zeroshot`</small> |
 
 ### Cross-geometry


### PR DESCRIPTION
Refresh all scores from Apr 14-15 run outputs: SAM3 points random improved significantly (23.691→13.552 MAE), several rankings reordered for zeroshot boxes and polygons splits.