### PR TITLE
Fix mini dataset download URL (404 on supervised mini zip)

### DIFF
--- a/src/milliontrees/datasets/TreeBoxes.py
+++ b/src/milliontrees/datasets/TreeBoxes.py
@@ -353,10 +353,8 @@ class TreeBoxesDataset(MillionTreesDataset):
                     f"MiniTreeBoxes_v{version}.zip")
                 mini_info['compressed_size'] = None
             if info.get('supervised_download_url'):
-                mini_info['supervised_download_url'] = info[
-                    'supervised_download_url'].replace(
-                        f"TreeBoxes_supervised_v{version}.zip",
-                        f"MiniTreeBoxes_supervised_v{version}.zip")
+                # Only full mini archives are published; supervised-only mini zips 404.
+                mini_info['supervised_download_url'] = None
             mini_versions[version] = mini_info
         return mini_versions
 

--- a/src/milliontrees/datasets/TreePoints.py
+++ b/src/milliontrees/datasets/TreePoints.py
@@ -256,10 +256,8 @@ class TreePointsDataset(MillionTreesDataset):
                     f"MiniTreePoints_v{version}.zip")
                 mini_info['compressed_size'] = None
             if info.get('supervised_download_url'):
-                mini_info['supervised_download_url'] = info[
-                    'supervised_download_url'].replace(
-                        f"TreePoints_supervised_v{version}.zip",
-                        f"MiniTreePoints_supervised_v{version}.zip")
+                # Only full mini archives are published; supervised-only mini zips 404.
+                mini_info['supervised_download_url'] = None
             mini_versions[version] = mini_info
         return mini_versions
 

--- a/src/milliontrees/datasets/TreePolygons.py
+++ b/src/milliontrees/datasets/TreePolygons.py
@@ -433,10 +433,8 @@ class TreePolygonsDataset(MillionTreesDataset):
                     f"MiniTreePolygons_v{version}.zip")
                 mini_info['compressed_size'] = None
             if info.get('supervised_download_url'):
-                mini_info['supervised_download_url'] = info[
-                    'supervised_download_url'].replace(
-                        f"TreePolygons_supervised_v{version}.zip",
-                        f"MiniTreePolygons_supervised_v{version}.zip")
+                # Only full mini archives are published; supervised-only mini zips 404.
+                mini_info['supervised_download_url'] = None
             mini_versions[version] = mini_info
         return mini_versions
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,25 +1,54 @@
-import pytest
+import copy
 import os
-from milliontrees.datasets import TreePolygons, TreeBoxes, TreePoints
+
+import pytest
 import urllib.request
 
-DATASET_CLASSES = [TreePolygons.TreePolygonsDataset, TreeBoxes.TreeBoxesDataset, TreePoints.TreePointsDataset]
+from milliontrees.datasets import TreeBoxes, TreePoints, TreePolygons
+
+DATASET_CLASSES = [
+    TreePolygons.TreePolygonsDataset, TreeBoxes.TreeBoxesDataset,
+    TreePoints.TreePointsDataset
+]
+
+
+def _mini_default_download_url(dataset_class):
+    """Effective download_url after mini + default (supervised) URL swap in __init__."""
+    obj = dataset_class.__new__(dataset_class)
+    obj._versions_dict = copy.deepcopy(dataset_class._versions_dict)
+    mini_versions = dataset_class._get_mini_versions_dict(obj)
+    modified_versions = {}
+    for v, info in mini_versions.items():
+        modified_info = dict(info)
+        if info.get('supervised_download_url') is not None:
+            modified_info['download_url'] = info['supervised_download_url']
+        modified_versions[v] = modified_info
+    return modified_versions
+
+
+@pytest.mark.parametrize("dataset_class,mini_basename", [
+    (TreePolygons.TreePolygonsDataset, "MiniTreePolygons_v0.12.zip"),
+    (TreeBoxes.TreeBoxesDataset, "MiniTreeBoxes_v0.12.zip"),
+    (TreePoints.TreePointsDataset, "MiniTreePoints_v0.12.zip"),
+])
+def test_mini_supervised_default_uses_full_mini_zip(dataset_class,
+                                                    mini_basename):
+    """Regression: published mini archives are full splits only; supervised mini zips 404."""
+    urls = _mini_default_download_url(dataset_class)
+    assert urls["0.12"]["download_url"].endswith(mini_basename)
+    assert "supervised" not in urls["0.12"]["download_url"]
+
 
 @pytest.mark.parametrize("dataset_class", DATASET_CLASSES)
 def test_dataset_url_exists(dataset_class, tmpdir):
-    """Test that dataset URLs exist but don't actually download"""
+    """Test that dataset URLs exist but don't actually download."""
     versions = dataset_class._versions_dict
     for version in versions:
         url = versions[version]['download_url']
         if url == "":
             continue
-        fpath = os.path.join(tmpdir, "test_data", "raw", os.path.basename(url))
         try:
             with urllib.request.urlopen(url) as response:
                 assert response.status == 200
         except urllib.error.URLError as e:
             pytest.fail(f"URL {url} is not accessible: {e}")
-            
-
-
-        


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/weecology/MillionTrees/issues/122

## Problem
With `mini=True` and default `include_unsupervised=False`, the package rewrote the download URL to `MiniTreePolygons_supervised_v0.12.zip` (and analogous URLs for boxes/points). Those archives are not published on the data server (HTTP 404), while `MiniTreePolygons_v0.12.zip` etc. return 200. The failed download left an empty or partial tree, which then led to `FileNotFoundError` for `random.csv`.

## Change
In `_get_mini_versions_dict` for `TreePolygons`, `TreeBoxes`, and `TreePoints`, set `supervised_download_url` to `None` for mini versions so the existing supervised-default logic keeps using the published full mini zip URL.

## Test
Added `test_mini_supervised_default_uses_full_mini_zip` in `tests/test_versions.py` to lock in the effective URL after the mini + supervised swap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d6c8dce-4be7-4e14-8c77-644c7a00ed7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d6c8dce-4be7-4e14-8c77-644c7a00ed7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

