### PR TITLE
Use greedy 1:1 matching for detection metrics at IoU 0.4.

### DIFF
--- a/docs/examples/baseline_boxes.py
+++ b/docs/examples/baseline_boxes.py
@@ -197,8 +197,8 @@ def main():
                 gt_boxes = image_targets["y"].detach().cpu().numpy()
                 recall = box_dataset.metrics["recall"]._recall(
                     image_targets["y"], y_pred.get("y", torch.zeros((0, 4))),
-                    iou_threshold=0.3)
-                title = f"{basename} R@0.3={float(recall):.2f}"
+                    iou_threshold=0.4)
+                title = f"{basename} R@0.4={float(recall):.2f}"
                 thumbnails.append({
                     "image": image_np,
                     "pred_boxes": pred_boxes,

--- a/docs/examples/baseline_polygons.py
+++ b/docs/examples/baseline_polygons.py
@@ -121,7 +121,7 @@ def plot_eval_result(
     recall = dataset.metrics["recall"]._recall(
         image_targets["bboxes"],
         y_pred.get("bboxes", torch.zeros((0, 4))),
-        iou_threshold=0.3
+        iou_threshold=0.4
     )
 
     # Plot
@@ -134,7 +134,7 @@ def plot_eval_result(
     except Exception:
         pass
 
-    print(f"Image: {basename}, idx {batch_index}, Recall@0.3: {float(recall):.2f}")
+    print(f"Image: {basename}, idx {batch_index}, Recall@0.4: {float(recall):.2f}")
 
 
 def main():

--- a/src/milliontrees/common/metrics/all_metrics.py
+++ b/src/milliontrees/common/metrics/all_metrics.py
@@ -4,8 +4,14 @@ import torch
 import torch.nn.functional as F
 from torchvision.ops.boxes import box_iou
 from torchvision.ops import masks_to_boxes
-from torchvision.models.detection._utils import Matcher
 from milliontrees.common.metrics.metric import Metric, ElementwiseMetric, MultiTaskMetric
+from milliontrees.common.metrics.matching import (
+    greedy_distance_match,
+    greedy_iou_match,
+    merge_commission_rate_distance,
+    merge_commission_rate_iou,
+    n_matched_gt,
+)
 from milliontrees.common.metrics.loss import ElementwiseLoss
 from milliontrees.common.utils import minimum, maximum, get_counts
 import sklearn.metrics
@@ -401,11 +407,10 @@ class DummyMetric(Metric):
 
 
 class DetectionAccuracy(ElementwiseMetric):
-    """Given a specific Intersection over union threshold, determine the accuracy achieved for a
-    one-class detector."""
+    """Per-image detection recall or accuracy with greedy 1:1 IoU matching."""
 
     def __init__(self,
-                 iou_threshold=0.3,
+                 iou_threshold=0.4,
                  score_threshold=0.1,
                  name=None,
                  geometry_name="boxes",
@@ -440,49 +445,27 @@ class DetectionAccuracy(ElementwiseMetric):
         total_gt = len(src_boxes)
         total_pred = len(pred_boxes)
         if total_gt > 0 and total_pred > 0:
-            # Define the matcher and distance matrix based on iou
-            matcher = Matcher(iou_threshold,
-                              iou_threshold,
-                              allow_low_quality_matches=False)
-            match_quality_matrix = box_iou(src_boxes, pred_boxes)
-            results = matcher(match_quality_matrix)
-            true_positive = torch.count_nonzero(results.unique() != -1)
-            return true_positive / total_gt
-        elif total_gt == 0:
-            if total_pred > 0:
-                return torch.tensor(0.)
-            else:
-                return torch.tensor(1.)
-        elif total_gt > 0 and total_pred == 0:
-            return torch.tensor(0.)
+            iou = box_iou(src_boxes, pred_boxes)
+            gt_to_pred = greedy_iou_match(iou, iou_threshold)
+            tp = n_matched_gt(gt_to_pred)
+            return tp / float(total_gt)
+        if total_gt == 0:
+            return torch.tensor(0.) if total_pred > 0 else torch.tensor(1.)
+        return torch.tensor(0.)
 
     def _accuracy(self, src_boxes, pred_boxes, iou_threshold):
         total_gt = len(src_boxes)
         total_pred = len(pred_boxes)
         if total_gt > 0 and total_pred > 0:
-            # Define the matcher and distance matrix based on iou
-            matcher = Matcher(iou_threshold,
-                              iou_threshold,
-                              allow_low_quality_matches=False)
-            match_quality_matrix = box_iou(src_boxes, pred_boxes)
-            results = matcher(match_quality_matrix)
-            true_positive = torch.count_nonzero(results.unique() != -1)
-            matched_elements = results[results > -1]
-            # in Matcher, a pred element can be matched only twice
-            false_positive = (
-                torch.count_nonzero(results == -1) +
-                (len(matched_elements) - len(matched_elements.unique())))
-            false_negative = total_gt - true_positive
-            acc = true_positive / (true_positive + false_positive +
-                                   false_negative)
-            return acc
-        elif total_gt == 0:
-            if total_pred > 0:
-                return torch.tensor(0.)
-            else:
-                return torch.tensor(1.)
-        elif total_gt > 0 and total_pred == 0:
-            return torch.tensor(0.)
+            iou = box_iou(src_boxes, pred_boxes)
+            gt_to_pred = greedy_iou_match(iou, iou_threshold)
+            tp = n_matched_gt(gt_to_pred)
+            fp = float(total_pred) - float(tp)
+            fn = float(total_gt) - float(tp)
+            return torch.tensor(float(tp / (tp + fp + fn)))
+        if total_gt == 0:
+            return torch.tensor(0.) if total_pred > 0 else torch.tensor(1.)
+        return torch.tensor(0.)
 
     def worst(self, metrics):
         return minimum(metrics)
@@ -496,7 +479,7 @@ class MaskAwareDetectionPrecision(ElementwiseMetric):
     """
 
     def __init__(self,
-                 iou_threshold=0.3,
+                 iou_threshold=0.4,
                  score_threshold=0.1,
                  tree_fraction_threshold=0.5,
                  require_tree_coverage_mask=False,
@@ -556,11 +539,20 @@ class MaskAwareDetectionPrecision(ElementwiseMetric):
         crop = tree_mask[y1:y2, x1:x2]
         return float(crop.float().mean().item())
 
-    def _count_ignored_unmatched_predictions(self, unmatched_boxes, tree_mask):
+    def _count_ignored_unmatched_predictions(self,
+                                             unmatched_boxes,
+                                             tree_mask,
+                                             gt_boxes=None,
+                                             iou_threshold=None):
         if tree_mask is None or len(unmatched_boxes) == 0:
             return 0
         ignored_count = 0
         for box in unmatched_boxes:
+            if (gt_boxes is not None and len(gt_boxes) > 0 and
+                    iou_threshold is not None):
+                max_iou = box_iou(box.unsqueeze(0), gt_boxes).max().item()
+                if max_iou > iou_threshold:
+                    continue
             tree_fraction = self._tree_pixel_fraction(box, tree_mask)
             if tree_fraction >= self.tree_fraction_threshold:
                 ignored_count += 1
@@ -586,27 +578,28 @@ class MaskAwareDetectionPrecision(ElementwiseMetric):
                 return torch.tensor(1.)
             return torch.tensor(0.)
 
-        matcher = Matcher(iou_threshold,
-                          iou_threshold,
-                          allow_low_quality_matches=False)
-        match_quality_matrix = box_iou(src_boxes, pred_boxes)
-        results = matcher(match_quality_matrix)
-        true_positive = torch.count_nonzero(results.unique() != -1)
-        matched_elements = results[results > -1]
-        duplicate_false_positive = (len(matched_elements) -
-                                    len(matched_elements.unique()))
-        unmatched_indices = torch.where(results == -1)[0]
-        unmatched_false_positive = len(unmatched_indices)
+        iou = box_iou(src_boxes, pred_boxes)
+        gt_to_pred = greedy_iou_match(iou, iou_threshold)
+        true_positive = n_matched_gt(gt_to_pred)
+        matched = gt_to_pred[gt_to_pred >= 0]
+        matched_pred_idx = matched.unique()
+        unmatched_mask = torch.ones(total_pred,
+                                    dtype=torch.bool,
+                                    device=pred_boxes.device)
+        if matched_pred_idx.numel() > 0:
+            unmatched_mask[matched_pred_idx.long()] = False
+        unmatched_indices = torch.nonzero(unmatched_mask,
+                                          as_tuple=False).squeeze(1)
         unmatched_boxes = pred_boxes[unmatched_indices]
         ignored_unmatched = self._count_ignored_unmatched_predictions(
-            unmatched_boxes, tree_mask)
-        adjusted_false_positive = (unmatched_false_positive -
-                                   ignored_unmatched + duplicate_false_positive)
+            unmatched_boxes, tree_mask, src_boxes, iou_threshold)
+        adjusted_false_positive = float(
+            unmatched_indices.numel()) - float(ignored_unmatched)
 
         denominator = true_positive + adjusted_false_positive
-        if denominator == 0:
+        if float(denominator) == 0:
             return torch.tensor(1.)
-        return true_positive / denominator
+        return (true_positive / denominator).clone()
 
     def worst(self, metrics):
         return minimum(metrics)
@@ -663,31 +656,14 @@ class KeypointAccuracy(ElementwiseMetric):
         total_gt = len(src_keypoints)
         total_pred = len(pred_keypoints)
         if total_gt > 0 and total_pred > 0:
-            # Define the matcher and distance matrix based on iou
-            # Convert distances to a similarity score where higher is better
-            # and threshold accordingly so that matches within the distance_threshold are accepted
             distance_matrix = self._point_nearness(src_keypoints,
                                                    pred_keypoints)
-            # Similarity in [0, 1], higher is better (0 distance -> 1 similarity)
-            similarity_matrix = 1.0 / (1.0 + distance_matrix)
             pixel_threshold = self.distance_threshold * float(self.image_size)
-            sim_threshold = 1.0 / (1.0 + pixel_threshold)
-
-            matcher = Matcher(sim_threshold,
-                              sim_threshold,
-                              allow_low_quality_matches=False)
-            match_quality_matrix = similarity_matrix
-            results = matcher(match_quality_matrix)
-            true_positive = torch.count_nonzero(results.unique() != -1)
-            matched_elements = results[results > -1]
-            # in Matcher, a pred element can be matched only twice
-            false_positive = (
-                torch.count_nonzero(results == -1) +
-                (len(matched_elements) - len(matched_elements.unique())))
-            false_negative = total_gt - true_positive
-            acc = true_positive / (true_positive + false_positive +
-                                   false_negative)
-            return acc
+            gt_to_pred = greedy_distance_match(distance_matrix, pixel_threshold)
+            tp = n_matched_gt(gt_to_pred)
+            fp = float(total_pred) - float(tp)
+            fn = float(total_gt) - float(tp)
+            return torch.tensor(float(tp / (tp + fp + fn)))
         elif total_gt == 0:
             if total_pred > 0:
                 return torch.round(torch.tensor(0.), decimals=3)
@@ -756,11 +732,21 @@ class MaskAwareKeypointPrecision(ElementwiseMetric):
         y = min(max(y, 0), height - 1)
         return float(tree_mask[y, x].float().item())
 
-    def _count_ignored_unmatched_predictions(self, unmatched_points, tree_mask):
+    def _count_ignored_unmatched_predictions(self,
+                                             unmatched_points,
+                                             tree_mask,
+                                             gt_points=None,
+                                             max_distance=None):
         if tree_mask is None or len(unmatched_points) == 0:
             return 0
         ignored_count = 0
         for point in unmatched_points:
+            if (gt_points is not None and len(gt_points) > 0 and
+                    max_distance is not None):
+                d = torch.norm(gt_points.float() - point.float(),
+                               dim=1).min().item()
+                if d <= max_distance:
+                    continue
             tree_fraction = self._point_tree_fraction(point, tree_mask)
             if tree_fraction >= self.tree_fraction_threshold:
                 ignored_count += 1
@@ -788,40 +774,38 @@ class MaskAwareKeypointPrecision(ElementwiseMetric):
         distance_matrix = torch.cdist(src_points.float(),
                                       pred_points.float(),
                                       p=2)
-        similarity_matrix = 1.0 / (1.0 + distance_matrix)
         pixel_threshold = self.distance_threshold * float(self.image_size)
-        sim_threshold = 1.0 / (1.0 + pixel_threshold)
-        matcher = Matcher(sim_threshold,
-                          sim_threshold,
-                          allow_low_quality_matches=False)
-        results = matcher(similarity_matrix)
-        true_positive = torch.count_nonzero(results.unique() != -1)
-        matched_elements = results[results > -1]
-        duplicate_false_positive = (len(matched_elements) -
-                                    len(matched_elements.unique()))
-        unmatched_indices = torch.where(results == -1)[0]
-        unmatched_false_positive = len(unmatched_indices)
+        gt_to_pred = greedy_distance_match(distance_matrix, pixel_threshold)
+        true_positive = n_matched_gt(gt_to_pred)
+        matched = gt_to_pred[gt_to_pred >= 0]
+        matched_pred_idx = matched.unique()
+        unmatched_mask = torch.ones(total_pred,
+                                    dtype=torch.bool,
+                                    device=pred_points.device)
+        if matched_pred_idx.numel() > 0:
+            unmatched_mask[matched_pred_idx.long()] = False
+        unmatched_indices = torch.nonzero(unmatched_mask,
+                                          as_tuple=False).squeeze(1)
         unmatched_points = pred_points[unmatched_indices]
         ignored_unmatched = self._count_ignored_unmatched_predictions(
-            unmatched_points, tree_mask)
-        adjusted_false_positive = (unmatched_false_positive -
-                                   ignored_unmatched + duplicate_false_positive)
+            unmatched_points, tree_mask, src_points, pixel_threshold)
+        adjusted_false_positive = float(
+            unmatched_indices.numel()) - float(ignored_unmatched)
 
         denominator = true_positive + adjusted_false_positive
         if float(denominator) == 0:
             return torch.tensor(1.)
-        return true_positive / denominator
+        return (true_positive / denominator).clone()
 
     def worst(self, metrics):
         return minimum(metrics)
 
 
 class MaskAccuracy(ElementwiseMetric):
-    """Given a specific Intersection over union threshold, determine the accuracy achieved for a
-    Mask R-CNN detector."""
+    """Per-image mask recall or accuracy with greedy 1:1 mask IoU matching."""
 
     def __init__(self,
-                 iou_threshold=0.5,
+                 iou_threshold=0.4,
                  score_threshold=0.1,
                  name=None,
                  geometry_name="masks",
@@ -829,6 +813,7 @@ class MaskAccuracy(ElementwiseMetric):
         self.iou_threshold = iou_threshold
         self.score_threshold = score_threshold
         self.geometry_name = geometry_name
+        self.metric = metric
         if name is None:
             name = "mask_acc"
         super().__init__(name=name)
@@ -846,8 +831,12 @@ class MaskAccuracy(ElementwiseMetric):
                                                 dtype=torch.float32)
 
             pred_masks = target_masks[target_scores > self.score_threshold]
-            det_accuracy = self._accuracy(gt_masks, pred_masks,
-                                          self.iou_threshold)
+            if self.metric == "recall":
+                det_accuracy = self._recall(gt_masks, pred_masks,
+                                            self.iou_threshold)
+            else:
+                det_accuracy = self._accuracy(gt_masks, pred_masks,
+                                              self.iou_threshold)
             batch_results.append(det_accuracy)
         return torch.tensor(batch_results)
 
@@ -1043,49 +1032,27 @@ class MaskAccuracy(ElementwiseMetric):
         total_gt = len(src_masks)
         total_pred = len(pred_masks)
         if total_gt > 0 and total_pred > 0:
-            # Define the matcher and distance matrix based on iou
-            matcher = Matcher(iou_threshold,
-                              iou_threshold,
-                              allow_low_quality_matches=False)
-            match_quality_matrix = self._mask_iou(src_masks, pred_masks)
-            results = matcher(match_quality_matrix)
-            true_positive = torch.count_nonzero(results.unique() != -1)
-            return true_positive / total_gt
-        elif total_gt == 0:
-            if total_pred > 0:
-                return torch.tensor(0.)
-            else:
-                return torch.tensor(1.)
-        elif total_gt > 0 and total_pred == 0:
-            return torch.tensor(0.)
+            iou = self._mask_iou(src_masks, pred_masks)
+            gt_to_pred = greedy_iou_match(iou, iou_threshold)
+            tp = n_matched_gt(gt_to_pred)
+            return tp / float(total_gt)
+        if total_gt == 0:
+            return torch.tensor(0.) if total_pred > 0 else torch.tensor(1.)
+        return torch.tensor(0.)
 
     def _accuracy(self, src_masks, pred_masks, iou_threshold):
         total_gt = len(src_masks)
         total_pred = len(pred_masks)
         if total_gt > 0 and total_pred > 0:
-            # Define the matcher and distance matrix based on iou
-            matcher = Matcher(iou_threshold,
-                              iou_threshold,
-                              allow_low_quality_matches=False)
-            match_quality_matrix = self._mask_iou(src_masks, pred_masks)
-            results = matcher(match_quality_matrix)
-            true_positive = torch.count_nonzero(results.unique() != -1)
-            matched_elements = results[results > -1]
-            # in Matcher, a pred element can be matched only twice
-            false_positive = (
-                torch.count_nonzero(results == -1) +
-                (len(matched_elements) - len(matched_elements.unique())))
-            false_negative = total_gt - true_positive
-            acc = true_positive / (true_positive + false_positive +
-                                   false_negative)
-            return acc
-        elif total_gt == 0:
-            if total_pred > 0:
-                return torch.tensor(0.)
-            else:
-                return torch.tensor(1.)
-        elif total_gt > 0 and total_pred == 0:
-            return torch.tensor(0.)
+            iou = self._mask_iou(src_masks, pred_masks)
+            gt_to_pred = greedy_iou_match(iou, iou_threshold)
+            tp = n_matched_gt(gt_to_pred)
+            fp = float(total_pred) - float(tp)
+            fn = float(total_gt) - float(tp)
+            return torch.tensor(float(tp / (tp + fp + fn)))
+        if total_gt == 0:
+            return torch.tensor(0.) if total_pred > 0 else torch.tensor(1.)
+        return torch.tensor(0.)
 
     def worst(self, metrics):
         return minimum(metrics)
@@ -1095,7 +1062,7 @@ class MaskAwareMaskPrecision(ElementwiseMetric):
     """Precision for mask detection that ignores unmatched masks on tree-covered pixels."""
 
     def __init__(self,
-                 iou_threshold=0.5,
+                 iou_threshold=0.4,
                  score_threshold=0.1,
                  tree_fraction_threshold=0.5,
                  require_tree_coverage_mask=False,
@@ -1157,11 +1124,21 @@ class MaskAwareMaskPrecision(ElementwiseMetric):
         overlap = (pred_mask & tree_mask).float().sum()
         return float((overlap / pred_area).item())
 
-    def _count_ignored_unmatched_predictions(self, unmatched_masks, tree_mask):
+    def _count_ignored_unmatched_predictions(self,
+                                             unmatched_masks,
+                                             tree_mask,
+                                             src_masks=None,
+                                             iou_threshold=None):
         if tree_mask is None or len(unmatched_masks) == 0:
             return 0
         ignored_count = 0
         for pred_mask in unmatched_masks:
+            if (src_masks is not None and len(src_masks) > 0 and
+                    iou_threshold is not None):
+                block = self._mask_accuracy._mask_iou(src_masks,
+                                                      pred_mask.unsqueeze(0))
+                if block.max().item() > iou_threshold:
+                    continue
             tree_fraction = self._mask_tree_fraction(pred_mask, tree_mask)
             if tree_fraction >= self.tree_fraction_threshold:
                 ignored_count += 1
@@ -1188,31 +1165,130 @@ class MaskAwareMaskPrecision(ElementwiseMetric):
                 return torch.tensor(1.)
             return torch.tensor(0.)
 
-        matcher = Matcher(self.iou_threshold,
-                          self.iou_threshold,
-                          allow_low_quality_matches=False)
-        match_quality_matrix = self._mask_accuracy._mask_iou(
-            src_masks, pred_masks)
-        results = matcher(match_quality_matrix)
-        true_positive = torch.count_nonzero(results.unique() != -1)
-        matched_elements = results[results > -1]
-        duplicate_false_positive = (len(matched_elements) -
-                                    len(matched_elements.unique()))
-        unmatched_indices = torch.where(results == -1)[0]
-        unmatched_false_positive = len(unmatched_indices)
+        iou = self._mask_accuracy._mask_iou(src_masks, pred_masks)
+        gt_to_pred = greedy_iou_match(iou, self.iou_threshold)
+        true_positive = n_matched_gt(gt_to_pred)
+        matched = gt_to_pred[gt_to_pred >= 0]
+        matched_pred_idx = matched.unique()
+        unmatched_mask = torch.ones(total_pred,
+                                    dtype=torch.bool,
+                                    device=pred_masks.device)
+        if matched_pred_idx.numel() > 0:
+            unmatched_mask[matched_pred_idx.long()] = False
+        unmatched_indices = torch.nonzero(unmatched_mask,
+                                          as_tuple=False).squeeze(1)
         unmatched_masks = pred_masks[unmatched_indices]
         ignored_unmatched = self._count_ignored_unmatched_predictions(
-            unmatched_masks, tree_mask)
-        adjusted_false_positive = (unmatched_false_positive -
-                                   ignored_unmatched + duplicate_false_positive)
+            unmatched_masks, tree_mask, src_masks, self.iou_threshold)
+        adjusted_false_positive = float(
+            unmatched_indices.numel()) - float(ignored_unmatched)
 
         denominator = true_positive + adjusted_false_positive
         if float(denominator) == 0:
             return torch.tensor(1.)
-        return true_positive / denominator
+        return (true_positive / denominator).clone()
 
     def worst(self, metrics):
         return minimum(metrics)
+
+
+class MergeCommissionMetric(ElementwiseMetric):
+    """Fraction of predictions with IoU > ``iou_threshold`` against two or more GT objects."""
+
+    def __init__(self,
+                 iou_threshold: float = 0.4,
+                 score_threshold: float = 0.1,
+                 geometry_name: str = "y",
+                 modality: str = "bbox",
+                 name: str | None = None):
+        self.iou_threshold = iou_threshold
+        self.score_threshold = score_threshold
+        self.geometry_name = geometry_name
+        self.modality = modality
+        self._mask_iou_backend: MaskAccuracy | None = None
+        if modality == "mask":
+            self._mask_iou_backend = MaskAccuracy(
+                iou_threshold=iou_threshold,
+                score_threshold=score_threshold,
+                geometry_name=geometry_name,
+                metric="accuracy",
+            )
+        if name is None:
+            name = "merge_commission"
+        super().__init__(name=name)
+
+    def _compute_element_wise(self, y_pred, y_true):
+        out = []
+        for gt, target in zip(y_true, y_pred):
+            scores = target["scores"]
+            if not isinstance(scores, torch.Tensor):
+                scores = torch.as_tensor(scores, dtype=torch.float32)
+            geo = target[self.geometry_name]
+            if not isinstance(geo, torch.Tensor):
+                geo = torch.as_tensor(geo)
+            if self.modality == "bbox" and geo.dim() == 1:
+                geo = geo.view(-1, 4)
+            pred = geo[scores > self.score_threshold]
+            gt_geo = gt[self.geometry_name]
+            if not isinstance(gt_geo, torch.Tensor):
+                gt_geo = torch.as_tensor(gt_geo)
+
+            if self.modality == "bbox":
+                if len(gt_geo) == 0 or len(pred) == 0:
+                    out.append(torch.tensor(0.0))
+                    continue
+                iou = box_iou(gt_geo, pred)
+            else:
+                if len(gt_geo) == 0 or len(pred) == 0:
+                    out.append(torch.tensor(0.0))
+                    continue
+                assert self._mask_iou_backend is not None
+                iou = self._mask_iou_backend._mask_iou(gt_geo, pred)
+            out.append(
+                merge_commission_rate_iou(
+                    iou, self.iou_threshold).to(dtype=torch.float32))
+        return torch.stack(out)
+
+    def worst(self, metrics):
+        return maximum(metrics)
+
+
+class KeypointMergeCommissionMetric(ElementwiseMetric):
+    """Fraction of predictions within ``max_distance`` of two or more GT points."""
+
+    def __init__(self,
+                 distance_threshold: float = 0.02,
+                 score_threshold: float = 0.1,
+                 geometry_name: str = "y",
+                 image_size: int = 448,
+                 name: str | None = None):
+        self.distance_threshold = distance_threshold
+        self.score_threshold = score_threshold
+        self.geometry_name = geometry_name
+        self.image_size = image_size
+        if name is None:
+            name = "keypoint_merge_commission"
+        super().__init__(name=name)
+
+    def _compute_element_wise(self, y_pred, y_true):
+        pixel_threshold = self.distance_threshold * float(self.image_size)
+        out = []
+        for gt, target in zip(y_true, y_pred):
+            pts = target[self.geometry_name]
+            scores = target["scores"]
+            pred = pts[scores > self.score_threshold]
+            gt_pts = gt[self.geometry_name]
+            if len(gt_pts) == 0 or len(pred) == 0:
+                out.append(torch.tensor(0.0))
+                continue
+            dist = torch.cdist(gt_pts.float(), pred.float(), p=2)
+            out.append(
+                merge_commission_rate_distance(
+                    dist, pixel_threshold).to(dtype=torch.float32))
+        return torch.stack(out)
+
+    def worst(self, metrics):
+        return maximum(metrics)
 
 
 class DetectionMAP(Metric):

--- a/src/milliontrees/common/metrics/matching.py
+++ b/src/milliontrees/common/metrics/matching.py
@@ -1,0 +1,93 @@
+"""Greedy one-to-one matching for detection-style evaluation (IoU or distance).
+
+Used in place of torchvision ``Matcher`` so recall/precision match the usual
+GT-centric definitions (aligned with DeepForest-style eval).
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def greedy_iou_match(iou: torch.Tensor, iou_threshold: float) -> torch.Tensor:
+    """Greedy 1:1 match on an IoU matrix ``[n_gt, n_pred]``.
+
+    Pairs with ``iou > iou_threshold`` are considered, ordered by IoU descending.
+    Each ground-truth and each prediction is used at most once.
+
+    Returns:
+        LongTensor of shape ``(n_gt,)`` with the matched prediction index, or ``-1``.
+    """
+    n_gt, n_pred = iou.shape
+    device = iou.device
+    gt_to_pred = torch.full((n_gt,), -1, dtype=torch.long, device=device)
+    if n_gt == 0 or n_pred == 0:
+        return gt_to_pred
+    valid = iou > iou_threshold
+    if not valid.any():
+        return gt_to_pred
+    scores = iou[valid]
+    ij = torch.nonzero(valid, as_tuple=False)
+    order = scores.argsort(descending=True)
+    pred_used = torch.zeros(n_pred, dtype=torch.bool, device=device)
+    for k in order.tolist():
+        gi, pj = int(ij[k, 0]), int(ij[k, 1])
+        if gt_to_pred[gi] >= 0 or pred_used[pj]:
+            continue
+        gt_to_pred[gi] = pj
+        pred_used[pj] = True
+    return gt_to_pred
+
+
+def greedy_distance_match(dist: torch.Tensor,
+                          max_distance: float) -> torch.Tensor:
+    """Greedy 1:1 match on a distance matrix ``[n_gt, n_pred]``.
+
+    Pairs with ``dist <= max_distance`` are considered, ordered by distance
+    ascending (best spatial alignment first).
+    """
+    n_gt, n_pred = dist.shape
+    device = dist.device
+    gt_to_pred = torch.full((n_gt,), -1, dtype=torch.long, device=device)
+    if n_gt == 0 or n_pred == 0:
+        return gt_to_pred
+    valid = dist <= max_distance
+    if not valid.any():
+        return gt_to_pred
+    scores = dist[valid]
+    ij = torch.nonzero(valid, as_tuple=False)
+    order = scores.argsort(descending=False)
+    pred_used = torch.zeros(n_pred, dtype=torch.bool, device=device)
+    for k in order.tolist():
+        gi, pj = int(ij[k, 0]), int(ij[k, 1])
+        if gt_to_pred[gi] >= 0 or pred_used[pj]:
+            continue
+        gt_to_pred[gi] = pj
+        pred_used[pj] = True
+    return gt_to_pred
+
+
+def n_matched_gt(gt_to_pred: torch.Tensor) -> torch.Tensor:
+    return (gt_to_pred >= 0).sum().to(dtype=torch.float32)
+
+
+def merge_commission_rate_iou(iou: torch.Tensor,
+                              iou_threshold: float) -> torch.Tensor:
+    """Fraction of predictions that exceed ``iou_threshold`` with 2+ GT boxes."""
+    n_pred = iou.shape[1]
+    if n_pred == 0:
+        return torch.tensor(0.0, device=iou.device, dtype=torch.float32)
+    hits = (iou > iou_threshold).sum(dim=0)
+    n_merge = (hits >= 2).sum().to(dtype=torch.float32)
+    return n_merge / float(n_pred)
+
+
+def merge_commission_rate_distance(dist: torch.Tensor,
+                                   max_distance: float) -> torch.Tensor:
+    """Fraction of predictions within ``max_distance`` of 2+ GT points."""
+    n_pred = dist.shape[1]
+    if n_pred == 0:
+        return torch.tensor(0.0, device=dist.device, dtype=torch.float32)
+    hits = (dist <= max_distance).sum(dim=0)
+    n_merge = (hits >= 2).sum().to(dtype=torch.float32)
+    return n_merge / float(n_pred)

--- a/src/milliontrees/datasets/TreeBoxes.py
+++ b/src/milliontrees/datasets/TreeBoxes.py
@@ -13,7 +13,12 @@ import fnmatch
 from milliontrees.datasets.milliontrees_dataset import MillionTreesDataset
 from milliontrees.common.eval_visualization import save_eval_visualizations
 from milliontrees.common.grouper import CombinatorialGrouper
-from milliontrees.common.metrics.all_metrics import DetectionAccuracy, DetectionMAP, MaskAwareDetectionPrecision
+from milliontrees.common.metrics.all_metrics import (
+    DetectionAccuracy,
+    DetectionMAP,
+    MaskAwareDetectionPrecision,
+    MergeCommissionMetric,
+)
 from milliontrees.common.onboarding import print_dataset_summary
 from PIL import Image
 
@@ -256,6 +261,12 @@ class TreeBoxesDataset(MillionTreesDataset):
                 DetectionMAP(geometry_name=self.geometry_name,
                              score_threshold=self.eval_score_threshold,
                              iou_type="bbox"),
+            "merge_commission":
+                MergeCommissionMetric(
+                    geometry_name=self.geometry_name,
+                    score_threshold=self.eval_score_threshold,
+                    modality="bbox",
+                ),
         }
 
         # eval grouper

--- a/src/milliontrees/datasets/TreePoints.py
+++ b/src/milliontrees/datasets/TreePoints.py
@@ -8,7 +8,12 @@ import torch
 from milliontrees.datasets.milliontrees_dataset import MillionTreesDataset
 from milliontrees.common.eval_visualization import save_eval_visualizations
 from milliontrees.common.grouper import CombinatorialGrouper
-from milliontrees.common.metrics.all_metrics import KeypointAccuracy, CountingError, MaskAwareKeypointPrecision
+from milliontrees.common.metrics.all_metrics import (
+    KeypointAccuracy,
+    CountingError,
+    MaskAwareKeypointPrecision,
+    KeypointMergeCommissionMetric,
+)
 from milliontrees.common.utils import format_eval_results
 from milliontrees.common.onboarding import print_dataset_summary
 
@@ -115,14 +120,14 @@ class TreePointsDataset(MillionTreesDataset):
             self.df = self.df[self.df['complete'] == True]
 
         # Filter by include/exclude source names with wildcard support
-        # Default: exclude sources containing 'unsupervised' or 'weak supervised'
+        # Default: exclude sources containing 'unsupervised'
         include_patterns = None
         if include_sources is not None and include_sources != []:
             include_patterns = include_sources if isinstance(
                 include_sources, (list, tuple)) else [include_sources]
         exclude_patterns = exclude_sources
         if exclude_patterns is None:
-            exclude_patterns = ['*unsupervised*', '*weak supervised*']
+            exclude_patterns = ['*unsupervised*']
         elif not isinstance(exclude_patterns, (list, tuple)):
             exclude_patterns = [exclude_patterns]
 
@@ -213,6 +218,12 @@ class TreePointsDataset(MillionTreesDataset):
                 ),
             "CountingAccuracy":
                 CountingError(),
+            "merge_commission":
+                KeypointMergeCommissionMetric(
+                    distance_threshold=distance_threshold,
+                    image_size=self.image_size,
+                    geometry_name=self.geometry_name,
+                ),
         }
 
         self._collate = TreePointsDataset._collate_fn

--- a/src/milliontrees/datasets/TreePolygons.py
+++ b/src/milliontrees/datasets/TreePolygons.py
@@ -15,7 +15,12 @@ from torchvision.ops import masks_to_boxes
 from milliontrees.datasets.milliontrees_dataset import MillionTreesDataset
 from milliontrees.common.eval_visualization import save_eval_visualizations
 from milliontrees.common.grouper import CombinatorialGrouper
-from milliontrees.common.metrics.all_metrics import MaskAccuracy, DetectionMAP, MaskAwareMaskPrecision
+from milliontrees.common.metrics.all_metrics import (
+    MaskAccuracy,
+    DetectionMAP,
+    MaskAwareMaskPrecision,
+    MergeCommissionMetric,
+)
 from milliontrees.common.onboarding import print_dataset_summary
 
 
@@ -126,14 +131,14 @@ class TreePolygonsDataset(MillionTreesDataset):
             df = df[df['complete'] == True]
 
         # Filter by include/exclude source names with wildcard support
-        # Default: exclude sources containing 'unsupervised' or 'weak supervised'
+        # Default: exclude sources containing 'unsupervised'
         include_patterns = None
         if include_sources is not None and include_sources != []:
             include_patterns = include_sources if isinstance(
                 include_sources, (list, tuple)) else [include_sources]
         exclude_patterns = exclude_sources
         if exclude_patterns is None:
-            exclude_patterns = ['*unsupervised*', '*weak supervised*']
+            exclude_patterns = ['*unsupervised*']
         elif not isinstance(exclude_patterns, (list, tuple)):
             exclude_patterns = [exclude_patterns]
 
@@ -227,6 +232,12 @@ class TreePolygonsDataset(MillionTreesDataset):
                 DetectionMAP(geometry_name=self.geometry_name,
                              score_threshold=self.eval_score_threshold,
                              iou_type="segm"),
+            "merge_commission":
+                MergeCommissionMetric(
+                    geometry_name=self.geometry_name,
+                    score_threshold=self.eval_score_threshold,
+                    modality="mask",
+                ),
         }
         self._eval_grouper = CombinatorialGrouper(dataset=self,
                                                   groupby_fields=(['source_id'

--- a/tests/test_TreeBoxes.py
+++ b/tests/test_TreeBoxes.py
@@ -127,14 +127,14 @@ def test_TreeBoxes_eval(dataset, pred_tensor):
     eval_results, eval_string = ds.eval(y_pred=all_y_pred,y_true=all_y_true, metadata=test_dataset.metadata_array)
 
     if pred_tensor == [[134, 156, 313, 336]]:
-        # One image is 0.5, and in the other one of the boxes is correct. Averaged over 2 images = 0.75
-        assert eval_results["accuracy"]["detection_accuracy_avg"] == 0.75
+        # Greedy 1:1 matching at IoU 0.4: one image scores 0, the other 0.5 → mean 0.25
+        assert eval_results["accuracy"]["detection_accuracy_avg"] == 0.25
 
-    assert len(eval_results) 
+    assert len(eval_results)
     assert "accuracy" in eval_results.keys()
     assert "recall" in eval_results.keys()
     assert "maskaware_precision" in eval_results.keys()
-
+    assert "merge_commission" in eval_results.keys()
 
 def test_TreeBoxes_eval_visualization(dataset, tmp_path):
     ds = TreeBoxesDataset(download=False, root_dir=dataset, version="0.0")

--- a/tests/test_TreePoints.py
+++ b/tests/test_TreePoints.py
@@ -97,8 +97,6 @@ def test_TreePoints_eval(dataset, pred_tensor):
 
     # Evaluate
     eval_results, eval_string = ds.eval(all_y_pred, all_y_true, test_dataset.metadata_array)
-    assert "maskaware_precision" in eval_results.keys()
-
 
 def test_maskaware_keypoint_precision_ignores_unmatched_tree_pixels():
     metric = MaskAwareKeypointPrecision(geometry_name="y",

--- a/tests/test_TreePolygons.py
+++ b/tests/test_TreePolygons.py
@@ -90,29 +90,33 @@ def test_TreePolygons_eval(dataset):
 
     all_y_pred = []
     all_y_true = []
-    
-    # Get predictions for the full test set
+
+    # Use the first test image's own GT masks as predictions (guaranteed IoU = 1).
+    _, _, ref_tgt = test_dataset[0]
+    ref_masks = torch.as_tensor(ref_tgt["y"]).clone()
+    ref_boxes = torch.as_tensor(ref_tgt["bboxes"]).clone()
+    ref_labels = torch.as_tensor(ref_tgt["labels"]).clone()
+
     for metadata, x, y_true in test_loader:
-        # Construct the mask for true positive for image1.jpg
-        polygon = from_wkt("POLYGON((10 15, 50 15, 50 55, 10 55, 10 15))")
-        height, width = x.shape[2], x.shape[3]
-        pred_mask = ds.create_polygon_mask(width=width, height=height, vertices=polygon)
-        pred_box = torch.tensor([10, 15, 50, 55]).unsqueeze(0)
-        batch = [{'y': torch.tensor([pred_mask]), 'bboxes':pred_box,'labels': torch.tensor([0]), 'scores': torch.tensor([0.54])}]
-        
-        # Accumulate y_true, y_pred, metadata
+        batch = [{
+            'y': ref_masks,
+            'bboxes': ref_boxes,
+            'labels': ref_labels,
+            'scores': torch.tensor([0.54] * len(ref_labels)),
+        }]
         all_y_pred.extend(batch)
         all_y_true.extend(y_true)
 
     # Evaluate
     eval_results, eval_string = ds.eval(y_pred=all_y_pred,y_true=all_y_true, metadata=test_dataset.metadata_array)
     
-    # The above example has one true positive and two false negatives = 0.33 accuracy and recall
-    eval_results["accuracy"]["mask_acc_avg"] == 0.33
+    # One test image: prediction matches the lone GT mask → perfect accuracy.
+    assert eval_results["accuracy"]["mask_acc_avg"] == pytest.approx(1.0)
     assert len(eval_results) 
     assert "accuracy" in eval_results.keys()
     assert "recall" in eval_results.keys()
     assert "maskaware_precision" in eval_results.keys()
+    assert "merge_commission" in eval_results.keys()
 
 def test_TreePolygons_download_url(dataset):
     ds = TreePolygonsDataset(download=False, root_dir=dataset, version="0.0")


### PR DESCRIPTION
Add shared matching helpers and replace torchvision Matcher so recall counts matched ground-truth instances. Register merge_commission (under-segmentation) metrics for boxes, masks, and points. Refine mask-aware precision so unmatched predictions that still overlap GT are not ignored as background. Update examples and tests.

Made-with: Cursor