### PR TITLE
Reduce release artifact size and enable RTD LFS images.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Build package artifacts
         run: uv build
 
+      - name: Guard source distribution size
+        run: |
+          SDIST_PATH="$(ls dist/*.tar.gz)"
+          SDIST_SIZE_MB="$(du -m "$SDIST_PATH" | cut -f1)"
+          echo "sdist path: $SDIST_PATH"
+          echo "sdist size: ${SDIST_SIZE_MB} MB"
+          test "$SDIST_SIZE_MB" -le 50
+
       - name: Create isolated virtual environment
         run: uv venv .venv-smoke
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,14 @@ jobs:
           python -m pip install build
           python -m build
 
+      - name: Guard source distribution size
+        run: |
+          SDIST_PATH="$(ls dist/*.tar.gz)"
+          SDIST_SIZE_MB="$(du -m "$SDIST_PATH" | cut -f1)"
+          echo "sdist path: $SDIST_PATH"
+          echo "sdist size: ${SDIST_SIZE_MB} MB"
+          test "$SDIST_SIZE_MB" -le 50
+
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,15 +4,24 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-
-python:
-  install:
-    - requirements: requirements.txt
-    - method: pip
-      path: .
-
-submodules:
-  include: []
+  jobs:
+    post_checkout:
+      - wget https://github.com/git-lfs/git-lfs/releases/download/v3.6.1/git-lfs-linux-amd64-v3.6.1.tar.gz
+      - tar xvfz git-lfs-linux-amd64-v3.6.1.tar.gz
+      - git config filter.lfs.process "`pwd`/git-lfs-3.6.1/git-lfs filter-process"
+      - git config filter.lfs.smudge "`pwd`/git-lfs-3.6.1/git-lfs smudge -- %f"
+      - git config filter.lfs.clean "`pwd`/git-lfs-3.6.1/git-lfs clean -- %f"
+      - ./git-lfs-3.6.1/git-lfs install
+      - ./git-lfs-3.6.1/git-lfs fetch
+      - ./git-lfs-3.6.1/git-lfs checkout
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ uv run pre-commit run --all-files
 
 Use `uv run pre-commit install` once per clone if you want the same checks to run automatically on `git commit`. Equivalent manual commands are documented in `docs/contributing.md`.
 
+### Agent gate before PR
+- Before opening or updating a PR, always run `uv run pre-commit run --all-files`.
+- If any hook fails (including docformatter), fix the files and rerun until all hooks pass.
+- Do not hand off a PR with known pre-commit failures.
+
 ## Coding Philosophy
 
 ### Code Style Preferences

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,18 @@ recursive-exclude * *.py[cod]
 recursive-exclude tests *
 recursive-exclude docs * 
 recursive-exclude data_prep *
+prune data-mini
+prune onboarding_data
+prune outputs
+prune training
+prune lightning_logs
+global-exclude *.png
+global-exclude *.jpg
+global-exclude *.jpeg
+global-exclude *.webp
+global-exclude *.tif
+global-exclude *.tiff
+global-exclude *.pt
+global-exclude *.ckpt
+global-exclude *.parquet
+global-exclude *.feather

--- a/src/milliontrees/common/eval_visualization.py
+++ b/src/milliontrees/common/eval_visualization.py
@@ -135,8 +135,8 @@ def save_eval_visualizations(
 
     Ground truth is drawn in purple; predictions above ``score_threshold`` are orange.
 
-    Images are resized to ``dataset.image_size`` so coordinates match ``y_pred`` / ``y_true``
-    from the standard eval loader.
+    Images are resized to ``dataset.image_size`` so coordinates match ``y_pred`` / ``y_true`` from
+    the standard eval loader.
 
     Returns paths of written PNG files.
     """

--- a/src/milliontrees/common/metrics/all_metrics.py
+++ b/src/milliontrees/common/metrics/all_metrics.py
@@ -68,7 +68,6 @@ def pseudolabel_binary_logits(logits, confidence_threshold):
                                               to NaN or discarded.
             - mask (Tensor): A mask indicating which predictions meet the confidence threshold.
     """
-
     if len(logits.shape) != 2:
         raise ValueError('Logits must be 2-dimensional.')
     probs = 1 / (1 + torch.exp(-logits))
@@ -100,7 +99,6 @@ def pseudolabel_multiclass_logits(logits, confidence_threshold):
             - pseudolabels_kept_frac (float): The fraction of examples retained after filtering.
             - mask (Tensor): A mask indicating which predictions meet the confidence threshold.
     """
-
     mask = torch.max(F.softmax(logits, -1), -1)[0] >= confidence_threshold
     unlabeled_y_pseudo = multiclass_logits_to_pred(logits)
     unlabeled_y_pseudo = unlabeled_y_pseudo[mask]
@@ -130,7 +128,6 @@ def pseudolabel_detection(preds, confidence_threshold):
         List[dict]: A filtered version of `preds`, where detections with confidence scores
                     below `confidence_threshold` are removed.
     """
-
     preds, pseudolabels_kept_frac = _mask_pseudolabels_detection(
         preds, confidence_threshold)
     unlabeled_y_pred = [{
@@ -168,7 +165,6 @@ def pseudolabel_detection_discard_empty(preds, confidence_threshold):
                     below `confidence_threshold` are removed. Entries with no remaining detections
                     are discarded from the list.
     """
-
     preds, pseudolabels_kept_frac = _mask_pseudolabels_detection(
         preds, confidence_threshold)
     unlabeled_y_pred = [{
@@ -474,8 +470,8 @@ class DetectionAccuracy(ElementwiseMetric):
 class MaskAwareDetectionPrecision(ElementwiseMetric):
     """Precision metric that avoids penalizing predictions on unannotated tree regions.
 
-    Unmatched predictions are excluded from false positives when enough of their box area
-    overlaps tree pixels from ``tree_coverage_mask``.
+    Unmatched predictions are excluded from false positives when enough of their box area overlaps
+    tree pixels from ``tree_coverage_mask``.
     """
 
     def __init__(self,

--- a/src/milliontrees/common/metrics/matching.py
+++ b/src/milliontrees/common/metrics/matching.py
@@ -1,7 +1,7 @@
 """Greedy one-to-one matching for detection-style evaluation (IoU or distance).
 
-Used in place of torchvision ``Matcher`` so recall/precision match the usual
-GT-centric definitions (aligned with DeepForest-style eval).
+Used in place of torchvision ``Matcher`` so recall/precision match the usual GT-centric definitions
+(aligned with DeepForest-style eval).
 """
 
 from __future__ import annotations
@@ -43,8 +43,8 @@ def greedy_distance_match(dist: torch.Tensor,
                           max_distance: float) -> torch.Tensor:
     """Greedy 1:1 match on a distance matrix ``[n_gt, n_pred]``.
 
-    Pairs with ``dist <= max_distance`` are considered, ordered by distance
-    ascending (best spatial alignment first).
+    Pairs with ``dist <= max_distance`` are considered, ordered by distance ascending (best spatial
+    alignment first).
     """
     n_gt, n_pred = dist.shape
     device = dist.device

--- a/src/milliontrees/common/metrics/metric.py
+++ b/src/milliontrees/common/metrics/metric.py
@@ -10,13 +10,14 @@ class Metric:
         self._name = name
 
     def _compute(self, y_pred, y_true):
-        """Helper function for computing the metric. Subclasses should implement this.
+        """Helper function for computing the metric.
 
-        Args:
-            - y_pred (Tensor): Predicted targets or model output
-            - y_true (Tensor): True targets
-        Output:
-            - metric (0-dim tensor): metric
+        Subclasses should implement this.
+                Args:
+                    - y_pred (Tensor): Predicted targets or model output
+                    - y_true (Tensor): True targets
+                Output:
+                    - metric (0-dim tensor): metric
         """
         return NotImplementedError
 
@@ -64,16 +65,17 @@ class Metric:
         return f'count_group:{group_idx}'
 
     def compute(self, y_pred, y_true, return_dict=True):
-        """Computes metric. This is a wrapper around _compute.
+        """Computes metric.
 
-        Args:
-            - y_pred (Tensor): Predicted targets or model output
-            - y_true (Tensor): True targets
-            - return_dict (bool): Whether to return the output as a dictionary or a tensor
-        Output (return_dict=False):
-            - metric (0-dim tensor): metric. If the inputs are empty, returns tensor(0.)
-        Output (return_dict=True):
-            - results (dict): Dictionary of results, mapping metric.agg_metric_field to avg_metric
+        This is a wrapper around _compute.
+                Args:
+                    - y_pred (Tensor): Predicted targets or model output
+                    - y_true (Tensor): True targets
+                    - return_dict (bool): Whether to return the output as a dictionary or a tensor
+                Output (return_dict=False):
+                    - metric (0-dim tensor): metric. If the inputs are empty, returns tensor(0.)
+                Output (return_dict=True):
+                    - results (dict): Dictionary of results, mapping metric.agg_metric_field to avg_metric
         """
         if numel(y_true) == 0:
             if hasattr(y_true, 'device'):
@@ -89,21 +91,22 @@ class Metric:
             return agg_metric
 
     def compute_group_wise(self, y_pred, y_true, g, n_groups, return_dict=True):
-        """Computes metrics for each group. This is a wrapper around _compute.
+        """Computes metrics for each group.
 
-        Args:
-            - y_pred (Tensor): Predicted targets or model output
-            - y_true (Tensor): True targets
-            - g (Tensor): groups
-            - n_groups (int): number of groups
-            - return_dict (bool): Whether to return the output as a dictionary or a tensor
-        Output (return_dict=False):
-            - group_metrics (Tensor): tensor of size (n_groups, ) including the average metric for each group
-            - group_counts (Tensor): tensor of size (n_groups, ) including the group count
-            - worst_group_metric (0-dim tensor): worst-group metric
-            - For empty inputs/groups, corresponding metrics are tensor(0.)
-        Output (return_dict=True):
-            - results (dict): Dictionary of results
+        This is a wrapper around _compute.
+                Args:
+                    - y_pred (Tensor): Predicted targets or model output
+                    - y_true (Tensor): True targets
+                    - g (Tensor): groups
+                    - n_groups (int): number of groups
+                    - return_dict (bool): Whether to return the output as a dictionary or a tensor
+                Output (return_dict=False):
+                    - group_metrics (Tensor): tensor of size (n_groups, ) including the average metric for each group
+                    - group_counts (Tensor): tensor of size (n_groups, ) including the group count
+                    - worst_group_metric (0-dim tensor): worst-group metric
+                    - For empty inputs/groups, corresponding metrics are tensor(0.)
+                Output (return_dict=True):
+                    - results (dict): Dictionary of results
         """
         group_metrics, group_counts, worst_group_metric = self._compute_group_wise(
             y_pred, y_true, g, n_groups)

--- a/src/milliontrees/common/utils.py
+++ b/src/milliontrees/common/utils.py
@@ -53,7 +53,6 @@ def split_into_groups(g):
             - unique_counts (Tensor): A tensor representing the count of each unique group
               in `groups`, with the same length as `groups`.
     """
-
     unique_groups, unique_counts = torch.unique(g,
                                                 sorted=False,
                                                 return_counts=True)
@@ -64,8 +63,9 @@ def split_into_groups(g):
 
 
 def get_counts(g, n_groups):
-    """This differs from split_into_groups in how it handles missing groups. get_counts always
-    returns a count array of length n_groups, whereas split_into_groups returns a unique_counts
+    """This differs from split_into_groups in how it handles missing groups.
+
+    get_counts always returns a count array of length n_groups, whereas split_into_groups returns a unique_counts
     array whose length is the number of unique groups present in g.
 
     Args:

--- a/src/milliontrees/datasets/TreeBoxes.py
+++ b/src/milliontrees/datasets/TreeBoxes.py
@@ -72,6 +72,7 @@ class TreeBoxesDataset(MillionTreesDataset):
 
     License: Creative Commons Attribution License
     """
+
     _dataset_name = 'TreeBoxes'
     _versions_dict = {
         # 0.0 is a placeholder for the testing dataset

--- a/src/milliontrees/datasets/TreePoints.py
+++ b/src/milliontrees/datasets/TreePoints.py
@@ -41,6 +41,7 @@ class TreePointsDataset(MillionTreesDataset):
     License:
         This dataset is distributed under Creative Commons Attribution License
     """
+
     _dataset_name = 'TreePoints'
     _versions_dict = {
         '0.0': {
@@ -288,7 +289,6 @@ class TreePointsDataset(MillionTreesDataset):
 
         Optional ``viz_dir`` / ``viz_n_per_source`` write qualitative overlays (see TreeBoxes.eval).
         """
-
         results = {}
         results_str = ''
         for metric in self.metrics:

--- a/src/milliontrees/datasets/TreePolygons.py
+++ b/src/milliontrees/datasets/TreePolygons.py
@@ -49,6 +49,7 @@ class TreePolygonsDataset(MillionTreesDataset):
     License:
         This dataset is distributed under the Creative Commons Attribution License.
     """
+
     _dataset_name = 'TreePolygons'
     _versions_dict = {
         '0.0': {

--- a/src/milliontrees/datasets/milliontrees_dataset.py
+++ b/src/milliontrees/datasets/milliontrees_dataset.py
@@ -504,9 +504,8 @@ class MillionTreesSubset(MillionTreesDataset):
     def __init__(self, dataset, indices, transform=None, geometry_name="y"):
         """This acts like `torch.utils.data.Subset`, but on `milliontreesDatasets`.
 
-        We
-        pass in `transform` (which is used for data augmentation) explicitly
-        because it can potentially vary on the training vs. test subsets.
+        We pass in `transform` (which is used for data augmentation) explicitly because it can
+        potentially vary on the training vs. test subsets.
         """
         self.dataset = dataset
         self.indices = indices

--- a/src/milliontrees/get_dataset.py
+++ b/src/milliontrees/get_dataset.py
@@ -1,4 +1,5 @@
 """Module for retrieving MillionTrees dataset instances."""
+
 from typing import Optional
 import milliontrees
 


### PR DESCRIPTION
Exclude large non-package assets from sdists, add CI checks to enforce a size limit, and configure Read the Docs to fetch Git LFS-managed docs images during builds.

Made-with: Cursor