### PR TITLE
Add OFO field-validated TreePoints dataset prep script

### DIFF
--- a/data_prep/process_ofo_field.py
+++ b/data_prep/process_ofo_field.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Process OFO field-validated tree maps into a MillionTrees TreePoints dataset.
+
+The Open Forest Observatory (OFO) ground-reference catalog contains stem maps where each tree is
+manually surveyed in the field and then registered to a specific drone mission's photogrammetry
+products. David Young provided a concatenated geopackage of 330 plot-drone pairs against the
+``missions_03`` photogrammetry run on the public ``ofo-public`` bucket at
+``https://js2.jetstream-cloud.org:8001``.
+
+For each unique ``mission_id`` in the field-trees file we download the matching orthomosaic from
+``drone/missions_03/{mission_id}/photogrammetry_03/full/{mission_id}_ortho-dsm-ptcloud.tif``, tile
+the orthomosaic into uniform patches, and emit per-tile point annotations in image coordinates with
+the standard MillionTrees columns. Trees marked ``withhold_from_training`` are routed to the test
+split. By default we also drop trees that are not flagged ``predicted_overstory`` since canopy-only
+field stems are the only ones expected to be visible from above.
+"""
+
+import argparse
+import os
+from typing import List, Optional
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import rasterio as rio
+from deepforest import preprocess
+from deepforest.utilities import read_file
+
+from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None
+
+OFO_ENDPOINT = 'https://js2.jetstream-cloud.org:8001'
+OFO_BUCKET = 'ofo-public'
+MISSION_PREFIX = 'drone/missions_03'
+
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def _require_requests():
+    import requests
+    return requests
+
+
+def _stream_download(url: str,
+                     dest_path: str,
+                     chunk_size: int = 1024 * 1024) -> None:
+    requests = _require_requests()
+    ensure_dir(os.path.dirname(dest_path))
+    with requests.get(url, stream=True, timeout=300) as r:
+        r.raise_for_status()
+        tmp_path = dest_path + ".part"
+        with open(tmp_path, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    f.write(chunk)
+        os.replace(tmp_path, dest_path)
+
+
+def download_mission_orthomosaic(
+    mission_id: str,
+    out_root: str,
+    endpoint: str = OFO_ENDPOINT,
+    bucket: str = OFO_BUCKET,
+) -> Optional[str]:
+    """Download a missions_03 orthomosaic for ``mission_id``.
+
+    Returns the local path to ``orthomosaic.tif`` on success, or None when no remote orthomosaic was
+    available. Trees registered against ``missions_03`` only point to the ``ortho-dsm-ptcloud.tif``
+    product in the ``photogrammetry_03/full/`` subfolder.
+    """
+    ortho_filename = f"{mission_id}_ortho-dsm-ptcloud.tif"
+    remote_url = (f"{endpoint.rstrip('/')}/swift/v1/{bucket}/"
+                  f"{MISSION_PREFIX}/{mission_id}/photogrammetry_03/full/"
+                  f"{ortho_filename}")
+    local_ortho = os.path.join(out_root, mission_id, 'photogrammetry_03',
+                               'full', 'orthomosaic.tif')
+
+    if os.path.exists(local_ortho):
+        return local_ortho
+
+    requests = _require_requests()
+    head = requests.head(remote_url, timeout=60, allow_redirects=True)
+    if head.status_code != 200:
+        print(f"  Warning: no ortho for {mission_id} ({head.status_code})")
+        return None
+
+    print(f"  Downloading orthomosaic for mission {mission_id}")
+    _stream_download(remote_url, local_ortho)
+    return local_ortho
+
+
+def load_field_trees(path: str,
+                     only_overstory: bool = True) -> gpd.GeoDataFrame:
+    """Read the concatenated OFO field-trees file and apply standard filtering.
+
+    Args:
+        path: Path to a geopackage / shapefile containing rows for each tree x mission pairing. The
+            schema is the ofo-public ground-reference schema augmented with ``mission_id``,
+            ``withhold_from_training`` and ``predicted_overstory`` per David Young's note.
+        only_overstory: When True, keep only trees flagged ``predicted_overstory`` (or where
+            ``ohvis`` is explicitly True). These are the trees expected to be detectable in nadir
+            drone imagery.
+
+    Returns:
+        A GeoDataFrame whose ``mission_id`` column is normalized to a 6-digit zero-padded string and
+        that has been filtered to overstory-visible trees by default.
+    """
+    gdf = gpd.read_file(path)
+
+    if 'mission_id' not in gdf.columns:
+        raise ValueError(
+            "Field trees file is missing the 'mission_id' column. "
+            "Per David Young's note, trees overlapping multiple missions should be duplicated with"
+            " a 'mission_id' attribute identifying the drone pairing.")
+
+    gdf['mission_id'] = (gdf['mission_id'].astype(str).str.split(
+        '-').str[0].str.zfill(6))
+
+    if only_overstory:
+        if 'predicted_overstory' in gdf.columns:
+            mask = gdf['predicted_overstory'].astype('boolean').fillna(False)
+            if 'ohvis' in gdf.columns:
+                mask = mask | gdf['ohvis'].astype('boolean').fillna(False)
+            gdf = gdf[mask].copy()
+        else:
+            print("Warning: 'predicted_overstory' missing; skipping overstory filter")
+
+    return gdf
+
+
+def tile_mission(
+    mission_id: str,
+    orthomosaic_path: str,
+    field_trees: gpd.GeoDataFrame,
+    images_dir: str,
+    patch_size: int = 800,
+) -> Optional[pd.DataFrame]:
+    """Tile a single mission's orthomosaic and project field trees into image coordinates.
+
+    Reuses ``deepforest.preprocess.split_raster`` after rewriting the orthomosaic as a clean
+    3-band uint8 raster (Jetstream2 orthos are 4-band float with NaNs, which split_raster cannot
+    consume directly).
+    """
+    mission_trees = field_trees[field_trees['mission_id'] == mission_id].copy()
+    if mission_trees.empty:
+        return None
+
+    with rio.open(orthomosaic_path) as src:
+        arr = src.read()
+        profile = src.profile.copy()
+        raster_crs = src.crs
+
+    arr[np.isnan(arr)] = 0
+    arr3 = arr[:3, :, :].astype(np.uint8)
+    profile.update(count=3, dtype=rio.uint8, nodata=0)
+
+    out_ortho = os.path.join(os.path.dirname(orthomosaic_path),
+                             f"{mission_id}_ortho.tif")
+    with rio.open(out_ortho, 'w', **profile) as dst:
+        dst.write(arr3)
+
+    if mission_trees.crs is not None and raster_crs is not None and mission_trees.crs != raster_crs:
+        mission_trees = mission_trees.to_crs(raster_crs)
+
+    mission_trees['image_path'] = os.path.basename(out_ortho)
+    mission_trees['label'] = 'Tree'
+    keep_cols = ['image_path', 'label', 'geometry']
+    if 'withhold_from_training' in mission_trees.columns:
+        mission_trees['withhold_from_training'] = mission_trees[
+            'withhold_from_training'].astype('boolean').fillna(False).astype(bool)
+        keep_cols.append('withhold_from_training')
+    df_for_split = mission_trees[keep_cols].copy()
+    df_for_split = read_file(df_for_split, root_dir=os.path.dirname(out_ortho))
+
+    points_tiled = preprocess.split_raster(
+        df_for_split,
+        path_to_raster=out_ortho,
+        root_dir=os.path.dirname(out_ortho),
+        save_dir=images_dir,
+        patch_size=patch_size,
+        patch_overlap=0,
+        allow_empty=False,
+    )
+
+    points_tiled = points_tiled.rename(columns={'image_path': 'filename'})
+    points_tiled['mission_id'] = str(mission_id)
+    points_tiled['source'] = 'OFO field 2025'
+
+    if 'withhold_from_training' in points_tiled.columns:
+        points_tiled['split'] = np.where(
+            points_tiled['withhold_from_training'].astype(bool), 'test',
+            'train')
+    else:
+        points_tiled['split'] = 'train'
+
+    return points_tiled
+
+
+def write_sample_overlays(images_dir: str,
+                          annotations_csv: str,
+                          savedir: str,
+                          max_samples: int = 8) -> None:
+    """Render a handful of patches with overlaid points for quick QC.
+
+    Trains/tests are colored differently so reviewers can see which trees are routed to the test
+    split via ``withhold_from_training``.
+    """
+    from matplotlib import pyplot as plt
+
+    ensure_dir(savedir)
+    df = pd.read_csv(annotations_csv)
+    df['basename'] = df['image_path'].apply(os.path.basename)
+    for basename in sorted(df['basename'].unique())[:max_samples]:
+        sub = df[df['basename'] == basename]
+        img = np.array(Image.open(os.path.join(images_dir, basename)))
+        fig, ax = plt.subplots(figsize=(8, 8))
+        ax.imshow(img)
+        train = sub[sub['split'] == 'train']
+        test = sub[sub['split'] == 'test']
+        if not train.empty:
+            ax.scatter(train['x'], train['y'], c='cyan', s=80, marker='+',
+                       linewidths=2.0, label='train')
+        if not test.empty:
+            ax.scatter(test['x'], test['y'], c='red', s=80, marker='x',
+                       linewidths=2.0, label='test (withheld)')
+        ax.set_title(f"{basename} — {len(sub)} field trees")
+        ax.legend(loc='upper right')
+        ax.axis('off')
+        fig.tight_layout()
+        fig.savefig(os.path.join(savedir, f"sample_points_{basename}"),
+                    dpi=120, bbox_inches='tight')
+        plt.close(fig)
+    print(f"Sample overlay plots written to {savedir}")
+
+
+def run(
+    field_trees_path: str,
+    output_dir: str,
+    ofo_root: str,
+    patch_size: int = 800,
+    num_missions: Optional[int] = None,
+    only_overstory: bool = True,
+    write_overlays: bool = False,
+    overlays_dir: Optional[str] = None,
+) -> str:
+    """End-to-end pipeline: download orthos, tile, write TreePoints_OFO_field.csv.
+
+    Returns the path of the written CSV.
+    """
+    ensure_dir(ofo_root)
+    images_dir = os.path.join(output_dir, 'images')
+    ensure_dir(images_dir)
+
+    field_trees = load_field_trees(field_trees_path,
+                                   only_overstory=only_overstory)
+    mission_ids = sorted(field_trees['mission_id'].unique())
+    if num_missions is not None:
+        mission_ids = mission_ids[:num_missions]
+    print(f"Processing {len(mission_ids)} missions: {mission_ids}")
+
+    tiled_records: List[pd.DataFrame] = []
+    for mid in mission_ids:
+        ortho_path = download_mission_orthomosaic(mid, ofo_root)
+        if ortho_path is None:
+            continue
+        tiled = tile_mission(mid, ortho_path, field_trees, images_dir,
+                             patch_size=patch_size)
+        if tiled is not None:
+            tiled_records.append(tiled)
+
+    if not tiled_records:
+        raise RuntimeError(
+            "No tiled annotations produced. Check field-trees mission_id values and orthomosaic"
+            " availability on Jetstream2.")
+
+    combined = pd.concat(tiled_records, ignore_index=True)
+    combined['image_path'] = combined['filename'].apply(
+        lambda fn: os.path.join(images_dir, fn))
+    combined = combined.drop(columns=['filename'])
+
+    out_csv = os.path.join(output_dir, 'TreePoints_OFO_field.csv')
+    combined.to_csv(out_csv, index=False)
+    print(f"Wrote {len(combined)} annotations across {combined['image_path'].nunique()} tiles to"
+          f" {out_csv}")
+
+    if write_overlays:
+        write_sample_overlays(images_dir, out_csv,
+                              overlays_dir or os.path.join(output_dir, 'sample_plots'))
+
+    return out_csv
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Build TreePoints_OFO_field dataset from OFO field-validated trees')
+    parser.add_argument('--field_trees', required=True,
+                        help='Geopackage of concatenated field trees with mission_id')
+    parser.add_argument('--output_dir', required=True,
+                        help='MillionTrees-style output directory (will contain images/)')
+    parser.add_argument('--ofo_root', required=True,
+                        help='Local cache dir for downloaded orthomosaics')
+    parser.add_argument('--patch_size', type=int, default=800)
+    parser.add_argument('--num_missions', type=int, default=None,
+                        help='Limit number of missions (handy for local tests)')
+    parser.add_argument('--include_understory', action='store_true',
+                        help='Keep trees regardless of predicted_overstory flag')
+    parser.add_argument('--sample_plots', action='store_true',
+                        help='Write per-tile QC overlay PNGs alongside the CSV')
+    parser.add_argument('--sample_plots_dir', default=None)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    run(
+        field_trees_path=args.field_trees,
+        output_dir=args.output_dir,
+        ofo_root=args.ofo_root,
+        patch_size=args.patch_size,
+        num_missions=args.num_missions,
+        only_overstory=not args.include_understory,
+        write_overlays=args.sample_plots,
+        overlays_dir=args.sample_plots_dir,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -429,3 +429,21 @@ https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.13860
 ***Location*** Forest across the United States
 
 ![sample_image](public/Young_et_al._2025_unsupervised.png)
+
+### Source Name: "OFO field 2025"
+
+Field-validated stem maps from the Open Forest Observatory ground reference catalog. David Young
+(UC Davis) shared a concatenated set of 330 plot-drone pairs in which each tree has been manually
+mapped on the ground and the plot has been algorithmically registered to a specific drone mission's
+photogrammetry products. The field trees are duplicated per overlapping mission with a
+``mission_id`` attribute denoting which orthomosaic each row should be paired with, and a
+``withhold_from_training`` flag that routes those trees to the test split.
+
+The dataset is built by ``data_prep/process_ofo_field.py``, which downloads the matching
+``missions_03`` orthomosaic for each ``mission_id`` from
+``https://js2.jetstream-cloud.org:8001/swift/v1/ofo-public/drone/missions_03/{mission_id}/photogrammetry_03/full/{mission_id}_ortho-dsm-ptcloud.tif``,
+tiles it into uniform patches, and projects field-tree points into image coordinates. Trees that
+are not flagged ``predicted_overstory`` (overhead visible) are dropped by default since field stems
+under the canopy cannot be observed from nadir drone imagery.
+
+***Location*** Forests across California (Sierra Nevada and Lake Tahoe basin), USA

--- a/slurm/submit_ofo_field.sh
+++ b/slurm/submit_ofo_field.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=ofo_field
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=b.weinstein@ufl.edu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=120GB
+#SBATCH --time=24:00:00
+#SBATCH --output=/home/b.weinstein/logs/ofo_field_%j.out
+#SBATCH --error=/home/b.weinstein/logs/ofo_field_%j.err
+
+uv sync --extra dev
+
+cd /blue/ewhite/b.weinstein/src/MillionTrees/data_prep
+
+# Path to the concatenated OFO field-trees gpkg shared by David Young (330 plot-drone pairs).
+# Update this to wherever the gpkg is staged on Orange.
+FIELD_TREES="/orange/ewhite/DeepForest/OpenForestObservatory/field/field_trees.gpkg"
+
+OUTPUT_DIR="/orange/ewhite/DeepForest/OpenForestObservatory/field"
+OFO_ROOT="/orange/ewhite/DeepForest/OpenForestObservatory/missions_03"
+
+mkdir -p "$OUTPUT_DIR" "$OFO_ROOT"
+
+echo "Starting OFO field-trees processing..."
+echo "Field trees: $FIELD_TREES"
+echo "Output directory: $OUTPUT_DIR"
+echo "OFO mission cache: $OFO_ROOT"
+
+uv run process_ofo_field.py \
+    --field_trees "$FIELD_TREES" \
+    --output_dir "$OUTPUT_DIR" \
+    --ofo_root "$OFO_ROOT" \
+    --patch_size 800 \
+    --sample_plots
+
+echo "OFO field-trees processing completed!"
+
+if [ -f "$OUTPUT_DIR/TreePoints_OFO_field.csv" ]; then
+    echo "Annotations rows: $(wc -l < "$OUTPUT_DIR/TreePoints_OFO_field.csv")"
+fi
+if [ -d "$OUTPUT_DIR/images" ]; then
+    echo "Tiled images: $(find "$OUTPUT_DIR/images" -name '*.png' | wc -l)"
+fi
+
+echo "Job completed at $(date)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `data_prep/process_ofo_field.py` pipeline for building a new MillionTrees TreePoints source from David Young's concatenated OFO field-validated stem maps (330 plot-drone pairs). The script:

- Reads a single field-trees geopackage where each row carries the standard OFO ground-reference attributes plus `mission_id`, `withhold_from_training`, `predicted_overstory`, and `ohvis` (per David's note).
- Filters to overhead-visible trees by default (`predicted_overstory` true, or overridden by direct `ohvis` observation), with `--include_understory` to opt out.
- Downloads the matching `missions_03` orthomosaic for each `mission_id` from the public Jetstream2 `ofo-public` bucket at `drone/missions_03/{mission_id}/photogrammetry_03/full/{mission_id}_ortho-dsm-ptcloud.tif` (the v03 photogrammetry the field trees were registered against).
- Tiles each ortho with `deepforest.preprocess.split_raster` and emits the standard MillionTrees columns (`image_path`, `x`, `y`, `label`, `geometry`, `source`, `split`) plus `mission_id` and `withhold_from_training` for traceability. Trees flagged `withhold_from_training` are routed to the `test` split per David's note.
- Source name `OFO field 2025`, distinct from the existing `Young et al. 2025 unsupervised`.

Also included:

- `slurm/submit_ofo_field.sh` to run the pipeline on HiPerGator.
- An entry under `Open Forest Observatory` in `docs/datasets.md` describing the new source and the pipeline.

## Walkthrough

End-to-end test was run locally on two real OFO missions (`000001`, `000002`) by downloading the v03 orthomosaics from Jetstream2 and feeding the script a synthetic field-trees geopackage built from real treetop geometries plus the expected schema (`mission_id`, `withhold_from_training`, `predicted_overstory`, `ohvis`, `species`, `dbh_cm`, `height_m`). The pipeline produced 116 annotations across 98 800x800 tiles with the correct CSV schema.

Mission-level overview — field tree points overlaid on the mission `000001` orthomosaic; cyan + are train, red x are `withhold_from_training` test trees:

[OFO mission 000001 overview](https://cursor.com/agents/bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fofo_field_mission_000001_overview.png)
[OFO mission 000002 overview](https://cursor.com/agents/bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fofo_field_mission_000002_overview.png)

Per-tile overlay on the tiled patch that the dataloader will actually consume — point coordinates land on real canopies after the geo-to-pixel projection, including a tile that mixes a train and a test annotation:

[Tile 000001_ortho_24 with train + test field trees](https://cursor.com/agents/bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsample_points_000001_ortho_24.png)
[Tile 000001_ortho_110 with three field trees](https://cursor.com/agents/bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsample_points_000001_ortho_110.png)
[Tile 000001_ortho_124 with a withheld field tree](https://cursor.com/agents/bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsample_points_000001_ortho_124.png)

## Notes / next steps

- The actual concatenated field-trees `.gpkg` from David is not staged on this VM, so the local end-to-end test used a synthetic gpkg with the expected schema sampled from real `missions_03` treetops (so the geometries align with real orthos and the CRS handling is exercised). Once the real file lands on Orange (`/orange/ewhite/DeepForest/OpenForestObservatory/field/field_trees.gpkg`), `slurm/submit_ofo_field.sh` runs the same pipeline against all 330 pairings and writes `TreePoints_OFO_field.csv` plus tiled imagery under `OUTPUT_DIR/images/`.
- The script intentionally only uses `missions_03` since that is the version the trees have been registered against; mission orthos that 404 on Jetstream2 are skipped with a warning rather than failing the whole run.

## Testing

- ✅ `uv run pre-commit run --all-files`
- ✅ `uv run python data_prep/process_ofo_field.py --field_trees ... --output_dir ... --ofo_root ... --num_missions 2 --sample_plots` (downloaded missions 000001 and 000002 from Jetstream2, tiled, produced 116 annotations across 98 tiles, sample overlays show points on canopies, train/test split honors `withhold_from_training`)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-985e3dd1-65b8-4d47-b27c-daaf1e11665e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

