### PR TITLE
Fix MillionTreesDataset length for image-indexed iteration

### DIFF
--- a/src/milliontrees/datasets/milliontrees_dataset.py
+++ b/src/milliontrees/datasets/milliontrees_dataset.py
@@ -36,7 +36,7 @@ class MillionTreesDataset:
         self.check_init()
 
     def __len__(self):
-        return len(self.y_array)
+        return len(self._input_array)
 
     def __getitem__(self, idx):
         # Any transformations are handled by the WILDSSubset

--- a/tests/test_TreeBoxes.py
+++ b/tests/test_TreeBoxes.py
@@ -36,6 +36,21 @@ def test_TreeBoxes_generic(dataset):
         assert metadata.shape == (2,)
         break
 
+
+def test_TreeBoxes_full_dataset_iteration(dataset):
+    ds = TreeBoxesDataset(download=False, root_dir=dataset, version="0.0")
+    assert len(ds) == len(ds._input_array) == 4
+
+    for idx in range(len(ds)):
+        metadata, image, targets = ds[idx]
+        boxes, labels = targets["y"], targets["labels"]
+        assert image.shape == (100, 100, 3)
+        assert image.dtype == np.float32
+        assert boxes.shape[1] == 4
+        assert len(labels) == len(boxes)
+        assert metadata.shape == (2,)
+
+
 # confirm that we can change target name is needed
 def test_get_dataset_with_geometry_name(dataset):
     ds = TreeBoxesDataset(download=False, root_dir=dataset, geometry_name="boxes",version="0.0") 


### PR DESCRIPTION
## Summary
- change `MillionTreesDataset.__len__` to return `len(self._input_array)` so dataset length matches image-indexed `__getitem__` access
- add `test_TreeBoxes_full_dataset_iteration` that iterates with `for idx in range(len(ds))` on the fixture and verifies each item is retrievable
- prevent `KeyError` when annotation count exceeds unique image count (production patch-release issue)

## Test plan
- [x] `uv run pytest tests/test_TreeBoxes.py -k \"generic or full_dataset_iteration\"`
- [x] `uv run pre-commit run --all-files`

Made with [Cursor](https://cursor.com)