### PR TITLE
Add TreeFinder (Wang et al. 2025) TreePolygons source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /data_prep/images_to_annotate/
 /data_prep/AutoArborist/
 /data_prep/neon_token.txt
+/data_prep/_treefinder_probe/
+/tiles224_v3.zip
+/tile_info224_v3*.csv
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -186,8 +189,14 @@ cython_debug/
 # IDE
 /.vscode/
 
-# Local training smoke checkpoints (too large for GitHub)
-training/boxes/outputs_smoke/checkpoints/*.ckpt
+# Local training run artifacts (outputs, checkpoints, lightning logs, SLURM logs)
+training/*/outputs/
+training/*/outputs_*/
+training/*/mini_test/
+training/**/lightning_logs/
+slurm/**/*.out
+training/slurm/*.out
+existing_models/*/outputs/
 
 # Comet ML credentials (copy .comet.config.example to .comet.config)
 .comet.config

--- a/data_prep/TreeFinder.py
+++ b/data_prep/TreeFinder.py
@@ -1,0 +1,163 @@
+"""
+Reproducible processor for Wang et al. 2025 (TreeFinder).
+
+Dataset: https://www.kaggle.com/datasets/zhihaow/tree-finder
+Mirror: https://huggingface.co/datasets/zhwang1/TreeFinder
+
+Tiles are 224×224 GeoTIFFs with bands [R, G, B, NIR, dead-tree mask].
+Dead-tree pixels (label=1) are vectorized to polygons for TreePolygons.
+
+Download (Hugging Face) then run:
+  TREE_FINDER_ROOT=/path/to/TreeFinder uv run python data_prep/TreeFinder.py
+
+Expected layout under TREE_FINDER_ROOT:
+  tile_info224_v3.csv
+  tiles224_v3.zip  (contains tiles224_v3/tiles224_v3/*.tif)
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pandas as pd
+import rasterio
+from shapely.geometry import Polygon
+
+SOURCE_NAME = "Wang et al. 2025"
+ZIP_TILE_PREFIX = "tiles224_v3/tiles224_v3/"
+MIN_POLYGON_AREA = 4
+NO_DATA_LABEL = 255
+
+DATASET_ROOT = Path(
+    os.environ.get("TREE_FINDER_ROOT",
+                   "/orange/ewhite/DeepForest/TreeFinder")).resolve()
+META_CSV = DATASET_ROOT / "tile_info224_v3.csv"
+ZIP_PATH = DATASET_ROOT / "tiles224_v3.zip"
+IMAGES_DIR = DATASET_ROOT / "images"
+OUT_CSV = DATASET_ROOT / "annotations.csv"
+PREVIEWS_DIR = DATASET_ROOT / "previews"
+
+
+def _polygons_from_label(label: np.ndarray) -> list[Polygon]:
+    mask = (label == 1).astype(np.uint8)
+    num, labels = cv2.connectedComponents(mask, connectivity=8)
+    polygons: list[Polygon] = []
+    for comp_id in range(1, num):
+        comp = (labels == comp_id).astype(np.uint8)
+        contours, _ = cv2.findContours(comp, cv2.RETR_EXTERNAL,
+                                       cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            continue
+        contour = max(contours, key=cv2.contourArea)
+        if cv2.contourArea(contour) < MIN_POLYGON_AREA:
+            continue
+        pts = contour.reshape(-1, 2)
+        poly = Polygon([(float(x), float(y)) for x, y in pts])
+        if not poly.is_valid:
+            poly = poly.buffer(0)
+        if poly.is_empty or poly.area < MIN_POLYGON_AREA:
+            continue
+        polygons.append(poly)
+    return polygons
+
+
+def _read_tile_arrays(tif_bytes: bytes) -> tuple[np.ndarray, np.ndarray]:
+    with rasterio.open(io.BytesIO(tif_bytes)) as src:
+        arr = src.read()
+    rgb = np.transpose(arr[:3], (1, 2, 0))
+    label = arr[4].astype(np.uint8)
+    label[label == NO_DATA_LABEL] = 0
+    return rgb, label
+
+
+def build_annotations(max_tiles: int | None = None) -> pd.DataFrame:
+    if not META_CSV.exists():
+        raise FileNotFoundError(f"Metadata CSV not found: {META_CSV}")
+    if not ZIP_PATH.exists():
+        raise FileNotFoundError(f"Tile archive not found: {ZIP_PATH}")
+
+    meta = pd.read_csv(META_CSV)
+    meta = meta[meta["LabelSize"] > 0]
+    if max_tiles is not None:
+        meta = meta.head(max_tiles)
+
+    IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+
+    with zipfile.ZipFile(ZIP_PATH) as zf:
+        for _, record in meta.iterrows():
+            zip_name = ZIP_TILE_PREFIX + record["FileName"]
+            tif_bytes = zf.read(zip_name)
+            rgb, label = _read_tile_arrays(tif_bytes)
+            polygons = _polygons_from_label(label)
+            if not polygons:
+                continue
+
+            png_name = Path(record["FileName"]).with_suffix(".png").name
+            png_path = IMAGES_DIR / png_name
+            if not png_path.exists():
+                cv2.imwrite(str(png_path),
+                            cv2.cvtColor(rgb.astype(np.uint8),
+                                         cv2.COLOR_RGB2BGR))
+
+            for poly in polygons:
+                xmin, ymin, xmax, ymax = poly.bounds
+                rows.append({
+                    "image_path": str(png_path.resolve()),
+                    "xmin": xmin,
+                    "ymin": ymin,
+                    "xmax": xmax,
+                    "ymax": ymax,
+                    "label": "Tree",
+                    "geometry": poly.wkt,
+                    "source": SOURCE_NAME,
+                })
+
+    if not rows:
+        raise RuntimeError("No polygon annotations were produced.")
+
+    df = pd.DataFrame(rows)
+    df.to_csv(OUT_CSV, index=False)
+    return df
+
+
+def generate_previews(df: pd.DataFrame, out_dir: Path, n: int = 1) -> list[str]:
+    from deepforest.utilities import read_file
+    from deepforest.visualize import plot_results
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    outputs: list[str] = []
+    for image_path in df["image_path"].drop_duplicates().head(n):
+        subset = df[df["image_path"] == image_path]
+        img = cv2.imread(image_path)
+        if img is None:
+            continue
+        rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        gdf = read_file(subset.copy(), root_dir=str(Path(image_path).parent))
+        gdf.root_dir = str(Path(image_path).parent)
+        basename = Path(image_path).stem
+        plot_results(gdf,
+                     savedir=str(out_dir),
+                     basename=basename,
+                     image=rgb,
+                     show=False)
+        outputs.append(str(out_dir / f"{basename}.png"))
+    return outputs
+
+
+def main():
+    df = build_annotations()
+    print(f"Wrote {len(df)} annotations across "
+          f"{df['image_path'].nunique()} images -> {OUT_CSV}")
+    previews = generate_previews(df, PREVIEWS_DIR, n=3)
+    for path in previews:
+        print(f"Preview: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data_prep/annotation_csvs.cfg
+++ b/data_prep/annotation_csvs.cfg
@@ -63,3 +63,4 @@
 /orange/ewhite/DeepForest/takeshige2025/crops/annotations.csv
 /orange/ewhite/DeepForest/Zenodo_19695972/annotations.csv
 /orange/ewhite/DeepForest/Hickman2021/annotations.csv
+/orange/ewhite/DeepForest/TreeFinder/annotations.csv

--- a/data_prep/source_completeness.csv
+++ b/data_prep/source_completeness.csv
@@ -39,3 +39,4 @@ source,complete
 "OSBS megaplot 2025",True
 "Bolhman 2008",True
 "OFO field 2025",True
+"Wang et al. 2025",False

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -542,6 +542,22 @@ Per-plot bounding box, point, and polygon annotations over NEON AOP camera image
 
 Urban tree crown polygons from the ITCD Urban Berlin/Osnabrück dataset, drawn over 20 cm DOP false-color orthoimagery and tiled for MillionTrees.
 
+## Wang et al. 2025 (TreeFinder)
+
+### Source Name: "Wang et al. 2025"
+
+![sample_image](public/Wang_et_al._2025.png)
+
+**Citation:** Wang, Zhihao, Cooper Li, Ruichen Wang, Lei Ma, George Hurtt, Xiaowei Jia, Gengchen Mai, Zhili Li, and Yiqun Xie. *TreeFinder: A US-Scale Benchmark Dataset for Individual Tree Mortality Monitoring Using High-Resolution Aerial Imagery.* NeurIPS 2025 Datasets and Benchmarks Track.
+
+**Links:** [Kaggle](https://www.kaggle.com/datasets/zhihaow/tree-finder) · [Hugging Face](https://huggingface.co/datasets/zhwang1/TreeFinder) · [Paper (OpenReview)](https://openreview.net/pdf?id=BH2miB6Smc)
+
+**Location:** Contiguous United States (48 states; 0.6 m NAIP aerial imagery)
+
+**Description:** Hand-labeled *dead-tree* segmentation tiles (224×224 px, RGB+NIR+mask). MillionTrees converts dead-tree mask instances to crown polygons (`TreePolygons`). Only tiles with mortality labels are packaged (~3.8k images, ~7.5k polygon rows); annotations are mortality-focused, not full-crown inventories (`complete=False`).
+
+**Preparation:** `data_prep/TreeFinder.py` (set `TREE_FINDER_ROOT` to the downloaded Hugging Face/Kaggle folder).
+
 ## Zuniga-Gonzalez et al. 2023
 
 ### Source Name: "Zuniga-Gonzalez et al. 2023"

--- a/docs/public/Wang_et_al._2025.png
+++ b/docs/public/Wang_et_al._2025.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6b87e281b5d34c6445b2ec1a46baa491e6a3c74cf3c4910b3a0d60b8da2199f
+size 59318


### PR DESCRIPTION
## Summary
- Adds `data_prep/TreeFinder.py` to convert TreeFinder 224×224 dead-tree mask tiles (Kaggle/Hugging Face) into MillionTrees polygon annotations (RGB PNG + WKT polygons).
- Registers `/orange/ewhite/DeepForest/TreeFinder/annotations.csv` in `annotation_csvs.cfg`, marks source `complete=False` in `source_completeness.csv`, and documents the dataset in `docs/datasets.md` with a sample overlay (`docs/public/Wang_et_al._2025.png`).
- Validated locally: downloaded HF metadata + one tile, mask vectorization aligns with imagery.

## Dataset size (TreeFinder → MillionTrees packaging)
| Metric | Value |
|--------|-------|
| Total tiles in release | 15,489 |
| Tiles with dead-tree labels | 3,773 |
| Estimated polygon rows after vectorization | ~7,500 |
| Archive size (`tiles224_v3.zip`) | ~2.0 GB |
| Tile size | 224×224 px (0.6 m NAIP; RGB+NIR+mask) |
| Geographic coverage | 48 US states |

Only labeled mortality tiles are packaged; annotations are dead-tree instances, not full-crown inventories.

## HPC follow-up
On the cluster, download [zhwang1/TreeFinder](https://huggingface.co/datasets/zhwang1/TreeFinder) (or Kaggle) to `/orange/ewhite/DeepForest/TreeFinder`, run `TREE_FINDER_ROOT=... uv run python data_prep/TreeFinder.py`, then re-run `package_datasets.py` for a release bump.

## Test plan
- [x] Sample tile overlay (`AL00000.tif` → `docs/public/Wang_et_al._2025.png`)
- [ ] Run `TreeFinder.py` on HPC after full download
- [ ] Include in next `package_datasets` / release cut

Made with [Cursor](https://cursor.com)