### PR TITLE
Speed up polygon stream eval with shared mask IoU and faster-coco-eval.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "scikit-learn",
     "shapely",
     "torchmetrics[detection]",
+    "faster-coco-eval",
     'albumentations',
     "pyarrow>=17.0.0",
     "datasets",

--- a/scripts/profile_polygon_eval.py
+++ b/scripts/profile_polygon_eval.py
@@ -1,0 +1,346 @@
+"""Profile TreePolygons evaluation on the mini (or full) dataset.
+
+Measures per-phase wall time, mask/pair counts, and cProfile hotspots for
+legacy ``dataset.eval()`` vs streaming ``TreePolygonsStreamingEvalState``.
+
+Example:
+    uv run python scripts/profile_polygon_eval.py --root-dir profiling_data --mini
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import pstats
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+
+from milliontrees import get_dataset
+from milliontrees.common.data_loaders import get_eval_loader
+from milliontrees.datasets.polygon_stream_eval import TreePolygonsStreamingEvalState
+
+
+@dataclass
+class DatasetStats:
+    n_images: int = 0
+    n_gt_masks: int = 0
+    n_pred_masks: int = 0
+    gt_masks_per_image: list[int] = field(default_factory=list)
+    pred_masks_per_image: list[int] = field(default_factory=list)
+    mask_pixels: int = 0
+
+    @property
+    def pairwise_gt_pred(self) -> int:
+        return sum(g * p for g, p in zip(self.gt_masks_per_image,
+                                         self.pred_masks_per_image))
+
+    @property
+    def avg_gt_per_image(self) -> float:
+        return self.n_gt_masks / max(self.n_images, 1)
+
+    @property
+    def avg_pred_per_image(self) -> float:
+        return self.n_pred_masks / max(self.n_images, 1)
+
+
+def _mock_preds_from_targets(targets: list[dict],
+                             *,
+                             pred_fraction: float = 1.0) -> list[dict]:
+    """Use GT masks as predictions (realistic dense crowns for timing)."""
+    preds: list[dict] = []
+    for target in targets:
+        gt_masks = target["y"]
+        if not isinstance(gt_masks, torch.Tensor):
+            gt_masks = torch.as_tensor(gt_masks)
+        gt_masks = gt_masks.to(torch.uint8)
+        if gt_masks.ndim == 2:
+            gt_masks = gt_masks.unsqueeze(0)
+        n = gt_masks.shape[0]
+        if n == 0:
+            preds.append({
+                "y": torch.zeros((0, 448, 448), dtype=torch.uint8),
+                "labels": torch.zeros((0,), dtype=torch.int64),
+                "scores": torch.zeros((0,), dtype=torch.float32),
+            })
+            continue
+        if pred_fraction <= 1.0:
+            keep_n = max(1, int(n * pred_fraction))
+            pred_masks = gt_masks[:keep_n]
+        else:
+            reps = int(pred_fraction)
+            pred_masks = gt_masks.repeat(reps, 1, 1)
+            keep_n = pred_masks.shape[0]
+        scores = torch.linspace(0.95, 0.55, keep_n)
+        preds.append({
+            "y": pred_masks,
+            "labels": torch.zeros((keep_n,), dtype=torch.int64),
+            "scores": scores,
+        })
+    return preds
+
+
+def _collect_stats(y_pred: list, y_true: list, score_threshold: float) -> DatasetStats:
+    stats = DatasetStats()
+    for pred, gt in zip(y_pred, y_true):
+        scores = pred["scores"]
+        if not isinstance(scores, torch.Tensor):
+            scores = torch.as_tensor(scores)
+        n_pred = int((scores > score_threshold).sum().item())
+        gt_masks = gt["y"]
+        n_gt = len(gt_masks)
+        stats.n_images += 1
+        stats.n_gt_masks += n_gt
+        stats.n_pred_masks += n_pred
+        stats.gt_masks_per_image.append(n_gt)
+        stats.pred_masks_per_image.append(n_pred)
+        if n_gt > 0:
+            stats.mask_pixels += int(gt_masks.shape[-2] * gt_masks.shape[-1] * n_gt)
+    return stats
+
+
+def _timed(label: str, fn, timings: dict[str, float]):
+    t0 = time.perf_counter()
+    out = fn()
+    timings[label] = time.perf_counter() - t0
+    return out
+
+
+def _profile_call(label: str, fn) -> tuple[object, str]:
+    pr = cProfile.Profile()
+    pr.enable()
+    t0 = time.perf_counter()
+    out = fn()
+    elapsed = time.perf_counter() - t0
+    pr.disable()
+    buf = io.StringIO()
+    ps = pstats.Stats(pr, stream=buf).sort_stats("cumulative")
+    ps.print_stats(25)
+    header = f"\n=== cProfile: {label} ({elapsed:.3f}s) ===\n"
+    return out, header + buf.getvalue()
+
+
+def _run_stream_eval(dataset, y_pred, y_true, metadata, timings: dict[str, float]):
+    state = TreePolygonsStreamingEvalState(dataset)
+    batch_size = 4
+    n = len(y_pred)
+    for start in range(0, n, batch_size):
+        end = min(start + batch_size, n)
+        batch_pred = y_pred[start:end]
+        batch_true = y_true[start:end]
+        batch_meta = metadata[start:end]
+        _timed(
+            "stream_update_batch",
+            lambda bp=batch_pred, bt=batch_true, bm=batch_meta: state.update(
+                bp, bt, bm),
+            timings,
+        )
+
+    for key in state._EW_KEYS:
+        _timed(
+            f"stream_finalize_ew_{key}",
+            lambda k=key: state._finalize_elementwise(k, dataset.metrics[k]),
+            timings,
+        )
+    _timed("stream_finalize_map_global", state._map_global.compute, timings)
+    gcnt = state._ew["accuracy"]["g_cnt"]
+    for gi in range(state._n_groups):
+        if gcnt[gi] <= 0:
+            continue
+        _timed(
+            f"stream_finalize_map_group_{gi}",
+            lambda g=gi: state._map_per_group[g].compute(),
+            timings,
+        )
+    return state.finalize()
+
+
+def _run_legacy_eval(dataset, y_pred, y_true, metadata, timings: dict[str, float]):
+    map_metric = dataset.metrics["AP50"]
+    for metric_name, metric in dataset.metrics.items():
+        if metric_name == "counting_mae":
+            continue
+        if hasattr(metric, "_compute_element_wise"):
+            _timed(
+                f"legacy_ew_{metric_name}",
+                lambda m=metric: m._compute_element_wise(y_pred, y_true),
+                timings,
+            )
+
+    _timed("legacy_map_format", lambda: map_metric._format(y_pred, y_true), timings)
+    preds, targets = map_metric._format(y_pred, y_true)
+    from torchmetrics.detection import MeanAveragePrecision
+
+    def _global_map():
+        m = MeanAveragePrecision(
+            iou_type=map_metric.iou_type,
+            iou_thresholds=map_metric.iou_thresholds,
+            max_detection_thresholds=map_metric.max_detection_thresholds,
+            class_metrics=False,
+        )
+        m.update(preds, targets)
+        return m.compute()
+
+    _timed("legacy_map_compute_global", _global_map, timings)
+
+    g = dataset._eval_grouper.metadata_to_group(metadata)
+    for gi in range(dataset._eval_grouper.n_groups):
+        mask = g == gi
+        if not mask.any():
+            continue
+        idx = mask.nonzero(as_tuple=True)[0].tolist()
+        gp = [y_pred[i] for i in idx]
+        gt = [y_true[i] for i in idx]
+
+        def _group_map(gp=gp, gt=gt):
+            m = MeanAveragePrecision(
+                iou_type=map_metric.iou_type,
+                iou_thresholds=map_metric.iou_thresholds,
+                max_detection_thresholds=map_metric.max_detection_thresholds,
+                class_metrics=False,
+            )
+            p2, t2 = map_metric._format(gp, gt)
+            m.update(p2, t2)
+            return m.compute()
+
+        _timed(f"legacy_map_compute_group_{gi}", _group_map, timings)
+
+    return None
+
+
+def _print_timings(title: str, timings: dict[str, float]) -> None:
+    print(f"\n{'=' * 60}")
+    print(title)
+    print(f"{'=' * 60}")
+    total = sum(timings.values())
+    for key, sec in sorted(timings.items(), key=lambda kv: -kv[1]):
+        pct = 100.0 * sec / total if total else 0.0
+        print(f"  {sec:8.3f}s  ({pct:5.1f}%)  {key}")
+    print(f"  {'—' * 8}")
+    print(f"  {total:8.3f}s  (100.0%)  [sum of labeled phases]")
+
+
+def _print_stats(stats: DatasetStats, n_groups: int) -> None:
+    print(f"\n{'=' * 60}")
+    print("Dataset / mask statistics (test split)")
+    print(f"{'=' * 60}")
+    print(f"  Images:              {stats.n_images}")
+    print(f"  Source groups:       {n_groups}")
+    print(f"  GT masks (total):    {stats.n_gt_masks}")
+    print(f"  Pred masks (total):  {stats.n_pred_masks}")
+    print(f"  Avg GT / image:      {stats.avg_gt_per_image:.1f}")
+    print(f"  Avg pred / image:    {stats.avg_pred_per_image:.1f}")
+    print(f"  Max GT / image:      {max(stats.gt_masks_per_image) if stats.gt_masks_per_image else 0}")
+    print(f"  Max pred / image:    {max(stats.pred_masks_per_image) if stats.pred_masks_per_image else 0}")
+    print(f"  Pairwise pred×GT:    {stats.pairwise_gt_pred:,}")
+    print(f"  Mask tensor pixels:  {stats.mask_pixels:,}  (H×W×N_gt, 448² each)")
+    full_scale_images = 1695
+    full_scale_factor = full_scale_images / max(stats.n_images, 1)
+    est_pairs_full = stats.pairwise_gt_pred * full_scale_factor
+    print(f"\n  Extrapolation to ~{full_scale_images} test images (full release):")
+    print(f"    Pairwise pred×GT ≈ {est_pairs_full:,.0f}")
+    print(f"    MAP compute calls: 1 global + {n_groups} per-source = {n_groups + 1}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root-dir", type=str, default="profiling_data")
+    parser.add_argument("--mini", action="store_true", default=True)
+    parser.add_argument("--no-mini", action="store_false", dest="mini")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--pred-fraction", type=float, default=1.0,
+                        help="Fraction of GT crowns kept as predictions (1.0 = dense).")
+    parser.add_argument("--profile-map-only", action="store_true",
+                        help="Run cProfile only on global MAP compute().")
+    args = parser.parse_args()
+
+    dataset = get_dataset(
+        "TreePolygons",
+        root_dir=args.root_dir,
+        mini=args.mini,
+        download=False,
+        split_scheme="random",
+        verbose=True,
+    )
+    test_subset = dataset.get_subset("test")
+    loader = get_eval_loader("standard", test_subset, batch_size=args.batch_size)
+
+    load_t0 = time.perf_counter()
+    all_y_true: list[dict] = []
+    for _, _, targets in loader:
+        all_y_true.extend(targets)
+    load_sec = time.perf_counter() - load_t0
+
+    all_y_pred = _mock_preds_from_targets(all_y_true,
+                                          pred_fraction=args.pred_fraction)
+    metadata = test_subset.metadata_array[:len(all_y_true)]
+    stats = _collect_stats(all_y_pred, all_y_true, dataset.eval_score_threshold)
+
+    print(f"\nDataloader: {load_sec:.3f}s for {len(all_y_true)} images")
+    _print_stats(stats, int(dataset._eval_grouper.n_groups))
+
+    if args.profile_map_only:
+        map_metric = dataset.metrics["AP50"]
+        preds, targets = map_metric._format(all_y_pred, all_y_true)
+        from torchmetrics.detection import MeanAveragePrecision
+
+        metric = MeanAveragePrecision(
+            iou_type=map_metric.iou_type,
+            iou_thresholds=map_metric.iou_thresholds,
+            max_detection_thresholds=map_metric.max_detection_thresholds,
+            class_metrics=False,
+        )
+        metric.update(preds, targets)
+        _, prof = _profile_call("AP50_global_compute", metric.compute)
+        print(prof)
+        return
+
+    legacy_timings: dict[str, float] = {}
+    stream_timings: dict[str, float] = {}
+
+    print("\nProfiling legacy metric phases...")
+    _run_legacy_eval(dataset, all_y_pred, all_y_true, metadata, legacy_timings)
+    _print_timings("Legacy eval phase timings", legacy_timings)
+
+    print("\nProfiling stream eval...")
+    stream_results, stream_prof = _profile_call(
+        "stream_eval_finalize",
+        lambda: _run_stream_eval(dataset, all_y_pred, all_y_true, metadata,
+                                 stream_timings),
+    )
+    _print_timings("Stream eval phase timings", stream_timings)
+    print(stream_prof)
+
+    print(f"\nStream eval summary (first lines):\n{stream_results[1][:400]}")
+
+    map_legacy = legacy_timings.get("legacy_map_compute_global", 0.0)
+    map_groups_legacy = sum(
+        v for k, v in legacy_timings.items() if k.startswith("legacy_map_compute_group_"))
+    map_stream = stream_timings.get("stream_finalize_map_global", 0.0)
+    map_groups_stream = sum(
+        v for k, v in stream_timings.items()
+        if k.startswith("stream_finalize_map_group_"))
+
+    print(f"\n{'=' * 60}")
+    print("AP50 compute() summary")
+    print(f"{'=' * 60}")
+    print(f"  Legacy  global compute:  {map_legacy:.3f}s")
+    print(f"  Legacy  per-group sum:   {map_groups_legacy:.3f}s  ({int(dataset._eval_grouper.n_groups)} groups)")
+    print(f"  Legacy  MAP total:       {map_legacy + map_groups_legacy:.3f}s")
+    print(f"  Stream  global compute:  {map_stream:.3f}s")
+    print(f"  Stream  per-group sum:   {map_groups_stream:.3f}s")
+    print(f"  Stream  MAP total:       {map_stream + map_groups_stream:.3f}s")
+
+    full_images = 1695
+    scale = full_images / max(stats.n_images, 1)
+    for label, t in [("Legacy MAP", map_legacy + map_groups_legacy),
+                     ("Stream MAP", map_stream + map_groups_stream)]:
+        est_hours = (t * scale) / 3600.0
+        print(f"\n  Extrapolated {label} on ~{full_images} images: {est_hours:.2f} hours")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/milliontrees/common/metrics/all_metrics.py
+++ b/src/milliontrees/common/metrics/all_metrics.py
@@ -18,6 +18,83 @@ import sklearn.metrics
 from scipy.stats import pearsonr
 
 
+def detection_map_backend() -> str:
+    """Prefer faster_coco_eval when installed; fall back to pycocotools."""
+    from torchmetrics.utilities.imports import _FASTER_COCO_EVAL_AVAILABLE
+    if _FASTER_COCO_EVAL_AVAILABLE:
+        return "faster_coco_eval"
+    return "pycocotools"
+
+
+def make_mean_average_precision(**kwargs):
+    """Construct torchmetrics MeanAveragePrecision with the fastest available backend."""
+    from torchmetrics.detection import MeanAveragePrecision
+    return MeanAveragePrecision(backend=detection_map_backend(), **kwargs)
+
+
+def compute_polygon_mask_elementwise_batch(
+    y_pred: list,
+    y_true: list,
+    *,
+    accuracy_metric: "MaskAccuracy",
+    recall_metric: "MaskAccuracy",
+    maskaware_metric: "MaskAwareMaskPrecision",
+    merge_metric: "MergeCommissionMetric",
+) -> dict[str, torch.Tensor]:
+    """Per-image elementwise polygon metrics with a single ``_mask_iou`` per image."""
+    acc_out: list[torch.Tensor] = []
+    rec_out: list[torch.Tensor] = []
+    map_out: list[torch.Tensor] = []
+    merge_out: list[torch.Tensor] = []
+
+    for gt, target in zip(y_true, y_pred):
+        scores = target["scores"]
+        if not isinstance(scores, torch.Tensor):
+            scores = torch.as_tensor(scores, dtype=torch.float32)
+        target_masks = target[accuracy_metric.geometry_name]
+        gt_masks = gt[accuracy_metric.geometry_name]
+        pred_masks = target_masks[scores > accuracy_metric.score_threshold]
+
+        total_gt = len(gt_masks)
+        total_pred = len(pred_masks)
+        if total_gt > 0 and total_pred > 0:
+            iou = accuracy_metric._mask_iou(gt_masks, pred_masks)
+        else:
+            iou = None
+
+        acc_out.append(
+            accuracy_metric._accuracy(gt_masks,
+                                      pred_masks,
+                                      accuracy_metric.iou_threshold,
+                                      iou=iou))
+        rec_out.append(
+            recall_metric._recall(gt_masks,
+                                  pred_masks,
+                                  recall_metric.iou_threshold,
+                                  iou=iou))
+
+        if total_gt == 0 or total_pred == 0:
+            merge_out.append(torch.tensor(0.0))
+        else:
+            merge_out.append(
+                merge_commission_rate_iou(
+                    iou, merge_metric.iou_threshold).to(dtype=torch.float32))
+
+        tree_mask = gt.get(maskaware_metric.tree_coverage_key)
+        map_out.append(
+            maskaware_metric._precision(gt_masks,
+                                        pred_masks,
+                                        tree_mask,
+                                        iou=iou))
+
+    return {
+        "accuracy": torch.stack(acc_out),
+        "recall": torch.stack(rec_out),
+        "maskaware_precision": torch.stack(map_out),
+        "merge_commission": torch.stack(merge_out),
+    }
+
+
 def binary_logits_to_score(logits):
     assert logits.dim() in (1, 2)
     if logits.dim() == 2:  #multi-class logits
@@ -1023,11 +1100,12 @@ class MaskAccuracy(ElementwiseMetric):
 
         return iou  # Returns [N, M] matrix
 
-    def _recall(self, src_masks, pred_masks, iou_threshold):
+    def _recall(self, src_masks, pred_masks, iou_threshold, *, iou=None):
         total_gt = len(src_masks)
         total_pred = len(pred_masks)
         if total_gt > 0 and total_pred > 0:
-            iou = self._mask_iou(src_masks, pred_masks)
+            if iou is None:
+                iou = self._mask_iou(src_masks, pred_masks)
             gt_to_pred = greedy_iou_match(iou, iou_threshold)
             tp = n_matched_gt(gt_to_pred)
             return tp / float(total_gt)
@@ -1035,11 +1113,12 @@ class MaskAccuracy(ElementwiseMetric):
             return torch.tensor(0.) if total_pred > 0 else torch.tensor(1.)
         return torch.tensor(0.)
 
-    def _accuracy(self, src_masks, pred_masks, iou_threshold):
+    def _accuracy(self, src_masks, pred_masks, iou_threshold, *, iou=None):
         total_gt = len(src_masks)
         total_pred = len(pred_masks)
         if total_gt > 0 and total_pred > 0:
-            iou = self._mask_iou(src_masks, pred_masks)
+            if iou is None:
+                iou = self._mask_iou(src_masks, pred_masks)
             gt_to_pred = greedy_iou_match(iou, iou_threshold)
             tp = n_matched_gt(gt_to_pred)
             fp = float(total_pred) - float(tp)
@@ -1125,24 +1204,25 @@ class MaskAwareMaskPrecision(ElementwiseMetric):
     def _count_ignored_unmatched_predictions(self,
                                              unmatched_masks,
                                              tree_mask,
-                                             src_masks=None,
+                                             *,
+                                             iou=None,
+                                             unmatched_indices=None,
                                              iou_threshold=None):
         if tree_mask is None or len(unmatched_masks) == 0:
             return 0
         ignored_count = 0
-        for pred_mask in unmatched_masks:
-            if (src_masks is not None and len(src_masks) > 0 and
-                    iou_threshold is not None):
-                block = self._mask_accuracy._mask_iou(src_masks,
-                                                      pred_mask.unsqueeze(0))
-                if block.max().item() > iou_threshold:
+        for local_idx, pred_mask in enumerate(unmatched_masks):
+            if (iou is not None and unmatched_indices is not None and
+                    iou_threshold is not None and iou.numel() > 0):
+                pred_col = int(unmatched_indices[local_idx])
+                if iou[:, pred_col].max().item() > iou_threshold:
                     continue
             tree_fraction = self._mask_tree_fraction(pred_mask, tree_mask)
             if tree_fraction >= self.tree_fraction_threshold:
                 ignored_count += 1
         return ignored_count
 
-    def _precision(self, src_masks, pred_masks, tree_mask):
+    def _precision(self, src_masks, pred_masks, tree_mask, *, iou=None):
         src_masks = self._prepare_masks(src_masks)
         pred_masks = self._prepare_masks(pred_masks)
         tree_mask = self._prepare_tree_mask(tree_mask)
@@ -1163,7 +1243,8 @@ class MaskAwareMaskPrecision(ElementwiseMetric):
                 return torch.tensor(1.)
             return torch.tensor(0.)
 
-        iou = self._mask_accuracy._mask_iou(src_masks, pred_masks)
+        if iou is None:
+            iou = self._mask_accuracy._mask_iou(src_masks, pred_masks)
         gt_to_pred = greedy_iou_match(iou, self.iou_threshold)
         true_positive = n_matched_gt(gt_to_pred)
         matched = gt_to_pred[gt_to_pred >= 0]
@@ -1177,7 +1258,12 @@ class MaskAwareMaskPrecision(ElementwiseMetric):
                                           as_tuple=False).squeeze(1)
         unmatched_masks = pred_masks[unmatched_indices]
         ignored_unmatched = self._count_ignored_unmatched_predictions(
-            unmatched_masks, tree_mask, src_masks, self.iou_threshold)
+            unmatched_masks,
+            tree_mask,
+            iou=iou,
+            unmatched_indices=unmatched_indices,
+            iou_threshold=self.iou_threshold,
+        )
         adjusted_false_positive = float(
             unmatched_indices.numel()) - float(ignored_unmatched)
 
@@ -1378,8 +1464,7 @@ class DetectionMAP(Metric):
 
     def _compute(self, y_pred, y_true):
         import torch
-        from torchmetrics.detection import MeanAveragePrecision
-        metric = MeanAveragePrecision(
+        metric = make_mean_average_precision(
             iou_type=self.iou_type,
             iou_thresholds=self.iou_thresholds,
             max_detection_thresholds=self.max_detection_thresholds,

--- a/src/milliontrees/datasets/polygon_stream_eval.py
+++ b/src/milliontrees/datasets/polygon_stream_eval.py
@@ -8,7 +8,11 @@ import numpy as np
 import torch
 
 from milliontrees.common.eval_visualization import save_eval_visualizations
-from milliontrees.common.metrics.all_metrics import DetectionMAP
+from milliontrees.common.metrics.all_metrics import (
+    DetectionMAP,
+    compute_polygon_mask_elementwise_batch,
+    make_mean_average_precision,
+)
 from milliontrees.common.utils import maximum, minimum
 
 
@@ -37,21 +41,17 @@ class TreePolygonsStreamingEvalState:
                 "g_cnt": torch.zeros(self._n_groups, dtype=torch.float64),
             }
 
-        from torchmetrics.detection import MeanAveragePrecision
-
         self._map_metric: DetectionMAP = dataset.metrics[self._MAP_KEY]
-        self._map_global = MeanAveragePrecision(
+        map_kwargs = dict(
             iou_type=self._map_metric.iou_type,
             iou_thresholds=self._map_metric.iou_thresholds,
             max_detection_thresholds=self._map_metric.max_detection_thresholds,
-            class_metrics=False)
+            class_metrics=False,
+        )
+        self._map_global = make_mean_average_precision(**map_kwargs)
         _disable_torchmetric_sync(self._map_global)
         self._map_per_group = [
-            MeanAveragePrecision(iou_type=self._map_metric.iou_type,
-                                 iou_thresholds=self._map_metric.iou_thresholds,
-                                 max_detection_thresholds=self._map_metric.
-                                 max_detection_thresholds,
-                                 class_metrics=False)
+            make_mean_average_precision(**map_kwargs)
             for _ in range(self._n_groups)
         ]
         for m in self._map_per_group:
@@ -67,9 +67,16 @@ class TreePolygonsStreamingEvalState:
             metadata = torch.as_tensor(metadata)
         g = self._grouper.metadata_to_group(metadata)
 
+        ew_scores = compute_polygon_mask_elementwise_batch(
+            y_pred,
+            y_true,
+            accuracy_metric=self._dataset.metrics["accuracy"],
+            recall_metric=self._dataset.metrics["recall"],
+            maskaware_metric=self._dataset.metrics["maskaware_precision"],
+            merge_metric=self._dataset.metrics["merge_commission"],
+        )
         for key in self._EW_KEYS:
-            metric = self._dataset.metrics[key]
-            v = metric._compute_element_wise(y_pred, y_true).float()
+            v = ew_scores[key].float()
             if v.device != g.device:
                 v = v.to(g.device)
             st = self._ew[key]


### PR DESCRIPTION
Reuse one _mask_iou matrix per image for elementwise metrics, fix mask-aware precision to use precomputed IoU columns, and prefer the faster_coco_eval MAP backend. Add a mini-dataset profiling script for regression checks.