### PR TITLE
Add Detectree2 pretrained baseline for TreePolygons

### DIFF
--- a/existing_models/detectree2/.gitignore
+++ b/existing_models/detectree2/.gitignore
@@ -1,0 +1,4 @@
+# Model garden checkpoints (downloaded, ~480MB each)
+*.pth
+# Locally downloaded MillionTrees data
+data/

--- a/existing_models/detectree2/README.md
+++ b/existing_models/detectree2/README.md
@@ -1,0 +1,58 @@
+# Detectree2 baseline (TreePolygons)
+
+[Detectree2](https://github.com/PatBall1/detectree2) is a Detectron2 Mask R-CNN
+for tree-crown delineation. We evaluate a pretrained `model_garden` checkpoint on
+the MillionTrees `TreePolygons` task and report the same metrics as the other
+`existing_models` runs.
+
+## Install
+
+Detectron2 has no PyPI release and must be built against the installed PyTorch, so
+install in steps (see the [detectree2 install docs](https://patball1.github.io/detectree2/installation.html)):
+
+```bash
+cd existing_models/detectree2
+uv venv --python 3.11
+source .venv/bin/activate
+
+# 1. PyTorch (pick the CUDA build for your cluster; CPU shown here)
+uv pip install torch torchvision
+
+# 2. Detectron2 (built from source against the torch above)
+uv pip install --no-build-isolation 'git+https://github.com/facebookresearch/detectron2.git'
+
+# 3. Detectree2 + MillionTrees (editable)
+uv pip install detectree2
+uv pip install -e ../..
+```
+
+## Download a checkpoint
+
+The `250312_flexi.pth` general RGB model (closed-canopy + urban) is a sensible
+default for the diverse MillionTrees imagery:
+
+```bash
+wget https://zenodo.org/records/15863800/files/250312_flexi.pth
+```
+
+Other options live in the [model garden](https://github.com/PatBall1/detectree2/tree/master/model_garden).
+
+## Run
+
+```bash
+uv run python eval_polygons.py \
+  --root-dir "$MT_ROOT" \
+  --split-scheme random \
+  --model-path 250312_flexi.pth \
+  --device cuda \
+  --output-dir outputs/random
+```
+
+Smoke test (a couple of batches, CPU):
+
+```bash
+uv run python eval_polygons.py --mini --max-batches 2 --device cpu \
+  --model-path 250312_flexi.pth
+```
+
+Outputs `results_polygons_<split>.txt` / `.json`, matching `existing_models/sam3`.

--- a/existing_models/detectree2/eval_polygons.py
+++ b/existing_models/detectree2/eval_polygons.py
@@ -1,0 +1,129 @@
+"""Evaluate a Detectree2 model_garden checkpoint on MillionTrees TreePolygons.
+
+Detectree2 (https://github.com/PatBall1/detectree2) is a Detectron2 Mask R-CNN
+trained for tree-crown delineation. We bypass its geospatial tiling pipeline and
+run the underlying Detectron2 ``DefaultPredictor`` directly on MillionTrees image
+tiles, then convert instance masks to the MillionTrees evaluation format:
+
+    {"y": Tensor[N, H, W] uint8, "labels": Tensor[N] int64, "scores": Tensor[N] float32}
+
+Download a checkpoint first (see README.md), e.g. ``250312_flexi.pth``.
+"""
+
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+
+from milliontrees import get_dataset
+from milliontrees.common.data_loaders import get_eval_loader
+
+
+def select_device(device_arg: str) -> str:
+    if device_arg == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return device_arg
+
+
+def build_predictor(model_path: str, base_model: str, device: str,
+                    score_threshold: float):
+    """Build a Detectron2 DefaultPredictor from a Detectree2 checkpoint."""
+    from detectree2.models.train import setup_cfg
+    from detectron2.engine import DefaultPredictor
+
+    cfg = setup_cfg(base_model=base_model, update_model=model_path)
+    cfg.MODEL.DEVICE = device
+    cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = score_threshold
+    return DefaultPredictor(cfg)
+
+
+def image_to_bgr_uint8(image: torch.Tensor) -> np.ndarray:
+    """MillionTrees image tensor (C,H,W float[0,1] RGB) -> HWC uint8 BGR.
+
+    Detectree2 checkpoints use ``cfg.INPUT.FORMAT == "BGR"`` and are trained on
+    cv2-read tiles, so we hand the predictor a BGR uint8 array.
+    """
+    rgb = (image.permute(1, 2, 0).clamp(0, 1).numpy() * 255).astype(np.uint8)
+    return np.ascontiguousarray(rgb[:, :, ::-1])
+
+
+def predict_one(predictor, image: torch.Tensor) -> dict:
+    outputs = predictor(image_to_bgr_uint8(image))
+    inst = outputs["instances"].to("cpu")
+    if len(inst) == 0:
+        h, w = image.shape[1:]
+        return {"y": torch.zeros((0, h, w), dtype=torch.uint8),
+                "labels": torch.zeros((0,), dtype=torch.int64),
+                "scores": torch.zeros((0,), dtype=torch.float32)}
+    masks = inst.pred_masks.to(torch.uint8)
+    scores = inst.scores.to(torch.float32)
+    return {"y": masks, "labels": torch.zeros(len(inst), dtype=torch.int64),
+            "scores": scores}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detectree2 on TreePolygons (instance masks).")
+    parser.add_argument("--root-dir", type=str,
+                        default=os.environ.get("MT_ROOT", "/orange/ewhite/web/public/MillionTrees"))
+    parser.add_argument("--model-path", type=str,
+                        default=os.environ.get("DETECTREE2_MODEL", "250312_flexi.pth"),
+                        help="Path to a Detectree2 model_garden .pth checkpoint.")
+    parser.add_argument("--base-model", type=str,
+                        default="COCO-InstanceSegmentation/mask_rcnn_R_101_FPN_3x.yaml")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--mini", action="store_true")
+    parser.add_argument("--download", action="store_true")
+    parser.add_argument("--split-scheme", type=str, default="random",
+                        choices=["random", "zeroshot", "crossgeometry"])
+    parser.add_argument("--device", type=str, default="auto", choices=["auto", "cpu", "cuda"])
+    parser.add_argument("--score-threshold", type=float, default=0.5)
+    parser.add_argument("--max-batches", type=int, default=None)
+    parser.add_argument("--output-dir", type=str, default=None)
+    parser.add_argument("--image-size", type=int, default=448)
+    parser.add_argument("--viz-dir", type=str, default=None,
+                        help="Directory for per-source prediction overlay PNGs")
+    args = parser.parse_args()
+
+    device = select_device(args.device)
+    predictor = build_predictor(args.model_path, args.base_model, device,
+                                args.score_threshold)
+
+    dataset = get_dataset("TreePolygons", root_dir=args.root_dir, download=args.download,
+                          mini=args.mini, split_scheme=args.split_scheme,
+                          image_size=args.image_size)
+    test_subset = dataset.get_subset("test")
+    test_loader = get_eval_loader("standard", test_subset, batch_size=args.batch_size,
+                                  num_workers=args.num_workers)
+
+    print(f"Batches: {len(test_loader)}")
+
+    all_y_pred, all_y_true = [], []
+    for b_idx, (metadata, images, targets) in enumerate(test_loader):
+        for image, target in zip(images, targets):
+            all_y_pred.append(predict_one(predictor, image))
+            all_y_true.append(target)
+        if args.max_batches is not None and (b_idx + 1) >= args.max_batches:
+            break
+
+    results, results_str = dataset.eval(
+        all_y_pred, all_y_true, metadata=test_subset.metadata_array[:len(all_y_true)],
+        viz_dir=args.viz_dir,
+    )
+    print(results_str)
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        with open(os.path.join(args.output_dir, f"results_polygons_{args.split_scheme}.txt"), "w") as f:
+            f.write(results_str)
+        flat = {k: float(v) if hasattr(v, "item") else v
+                for k, v in results.items() if isinstance(v, (int, float, torch.Tensor))}
+        with open(os.path.join(args.output_dir, f"results_polygons_{args.split_scheme}.json"), "w") as f:
+            json.dump({"model": "Detectree2", "task": "TreePolygons",
+                       "split": args.split_scheme, "metrics": flat}, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/existing_models/detectree2/pyproject.toml
+++ b/existing_models/detectree2/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "milliontrees-detectree2"
+version = "0.1.0"
+description = "Detectree2 (Mask R-CNN tree crown delineation) evaluation on MillionTrees TreePolygons"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    "milliontrees",
+    "detectree2",
+    "torch",
+    "torchvision",
+    "opencv-python",
+]
+
+[tool.uv.sources]
+milliontrees = { path = "../..", editable = true }
+
+# detectron2 has no PyPI release and must be built against the installed torch.
+# Install it (and detectree2) following README.md; uv cannot resolve it from PyPI.

--- a/existing_models/slurm/eval_detectree2.sbatch
+++ b/existing_models/slurm/eval_detectree2.sbatch
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH --job-name=mt_eval_detectree2
+#SBATCH --output=/home/b.weinstein/logs/%x_%A_%a.out
+#SBATCH --error=/home/b.weinstein/logs/%x_%A_%a.err
+#SBATCH --array=0-1
+#SBATCH --time=24:00:00
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=100G
+#SBATCH --partition=hpg-turin
+#SBATCH --gpus=1
+
+set -euo pipefail
+
+REPO=/blue/ewhite/b.weinstein/src/MillionTrees
+ROOT_DIR=${MT_ROOT:-/orange/ewhite/web/public/MillionTrees}
+SPLITS=(random zeroshot)
+SPLIT=${SPLITS[$SLURM_ARRAY_TASK_ID]}
+OUT_BASE=$REPO/existing_models/detectree2/outputs/$SPLIT
+
+cd $REPO/existing_models/detectree2
+
+# Download the model_garden checkpoint once (cached afterwards).
+MODEL=250312_flexi.pth
+if [ ! -f "$MODEL" ]; then
+  wget -q https://zenodo.org/records/15863800/files/$MODEL
+fi
+
+echo "=== Detectree2 eval: split=$SPLIT ==="
+
+uv run python eval_polygons.py \
+  --root-dir "$ROOT_DIR" \
+  --split-scheme "$SPLIT" \
+  --device cuda \
+  --batch-size 8 \
+  --model-path "$MODEL" \
+  --output-dir "$OUT_BASE"
+
+echo "=== Detectree2 eval done. Results in $OUT_BASE ==="

--- a/existing_models/slurm/submit_all_eval.sh
+++ b/existing_models/slurm/submit_all_eval.sh
@@ -13,4 +13,7 @@ sbatch existing_models/slurm/eval_treeformer.sbatch
 echo "Submitting SAM3 evaluation..."
 sbatch existing_models/slurm/eval_sam3.sbatch
 
+echo "Submitting Detectree2 (pretrained polygon model) evaluation..."
+sbatch existing_models/slurm/eval_detectree2.sbatch
+
 echo "All eval jobs submitted."


### PR DESCRIPTION
Mirror the existing_models eval format with a Detectree2 (Detectron2 Mask R-CNN) baseline: run the model_garden checkpoint directly on MillionTrees tiles, convert instance masks to the MT eval format, and emit results_polygons_<split>.{txt,json} like the SAM3 baseline. Includes an isolated pyproject, install/run README, and a SLURM job wired into submit_all_eval.sh.