### PR TITLE
Add SelvaMask polygon dataset

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          uv sync --all-extras --dev
+          uv sync --all-extras --all-groups
           uv pip install nbqa
 
       - name: Verify nbqa installation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 # use uv (https://github.com/astral-sh/uv):
 
 ```bash
-uv sync --extra dev
+uv sync --group dev
 uv run python
 ```
 
@@ -13,7 +13,7 @@ uv run python
 CI runs [pre-commit](https://pre-commit.com/) hooks (YAPF and docformatter on `src/milliontrees/`). **Pull requests must pass `pre-commit` before merge**; fix style locally instead of relying on CI to fail.
 
 ```bash
-uv sync --extra dev
+uv sync --group dev
 uv run pre-commit run --all-files
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ To build from the GitHub source and install the required dependencies, follow th
     cd MillionTrees
     ```
 
-3. (Recommended) Create and activate a virtual environment, then install dev extras:
+3. (Recommended) Install the dev tooling and docs dependencies with uv (the `dev`
+   dependency group is installed by default):
     ```
-    python -m venv .venv && source .venv/bin/activate
-    pip install -e .[dev,docs]
+    uv sync --extra docs
     ```
 
 4. (Optional) Build distributions:

--- a/data_prep/SelvaMask.py
+++ b/data_prep/SelvaMask.py
@@ -1,0 +1,105 @@
+"""Prepare the SelvaMask tropical tree-crown segmentation dataset for MillionTrees.
+
+SelvaMask (https://huggingface.co/datasets/selvamask/SelvaMask) ships COCO-style
+polygon annotations stored in HuggingFace parquet shards across ``train``,
+``validation`` and ``test`` splits. Each row is an RGB tile with crown polygons
+in pixel coordinates relative to the tile origin (0, 0 = top-left), which is
+already the MillionTrees image coordinate convention.
+
+We honor the published split: the HF ``test`` split becomes ``existing_split ==
+"test"`` and ``train`` + ``validation`` are folded into ``train`` (MillionTrees
+only carries a train/test split, and validation is an intermediate set).
+"""
+import io
+import os
+
+import geopandas as gpd
+import pandas as pd
+import requests
+from PIL import Image
+from shapely.geometry import Polygon
+from tqdm import tqdm
+
+Image.MAX_IMAGE_PIXELS = None
+
+SOURCE = "SelvaMask"
+DATASET_NAME = "selvamask/SelvaMask"
+OUTPUT_DIR = "/orange/ewhite/DeepForest/SelvaMask"
+
+
+def polygon_from_segmentation(segmentation):
+    """Build a shapely Polygon from a COCO segmentation entry.
+
+    ``segmentation`` is a list of rings; each ring is a flat ``[x1, y1, x2, y2,
+    ...]`` list. We use the first (exterior) ring and drop annotations with
+    fewer than three vertices.
+    """
+    if not segmentation:
+        return None
+    ring = segmentation[0]
+    coords = list(zip(ring[0::2], ring[1::2]))
+    if len(coords) < 3:
+        return None
+    return Polygon(coords)
+
+
+def download_selvamask(force_download=False):
+    """Download SelvaMask parquet shards, write PNG tiles and a polygon CSV."""
+    images_dir = os.path.join(OUTPUT_DIR, "images")
+    cache_dir = os.path.join(OUTPUT_DIR, "cache")
+    annotations_csv = os.path.join(OUTPUT_DIR, "annotations.csv")
+
+    if not force_download and os.path.exists(annotations_csv):
+        print(f"Dataset already exists at {annotations_csv}; pass force_download=True to rebuild.")
+        return annotations_csv
+
+    os.makedirs(images_dir, exist_ok=True)
+    os.makedirs(cache_dir, exist_ok=True)
+
+    api_url = f"https://datasets-server.huggingface.co/parquet?dataset={DATASET_NAME}"
+    parquet_files = requests.get(api_url).json()["parquet_files"]
+
+    records = []
+    for file_info in parquet_files:
+        split = file_info["split"]
+        existing_split = "test" if split == "test" else "train"
+        cached_parquet = os.path.join(cache_dir, f"{split}_{file_info['filename']}")
+
+        if force_download or not os.path.exists(cached_parquet):
+            print(f"Downloading {split}/{file_info['filename']} ...")
+            response = requests.get(file_info["url"], stream=True)
+            response.raise_for_status()
+            with open(cached_parquet, "wb") as f:
+                for chunk in response.iter_content(chunk_size=1 << 20):
+                    f.write(chunk)
+
+        df = pd.read_parquet(cached_parquet)
+        for _, row in tqdm(df.iterrows(), total=len(df), desc=f"Processing {split}"):
+            image_filename = os.path.splitext(row["tile_name"])[0] + ".png"
+            image_path = os.path.join(images_dir, image_filename)
+            if force_download or not os.path.exists(image_path):
+                with Image.open(io.BytesIO(row["image"]["bytes"])) as img:
+                    img.convert("RGB").save(image_path, "PNG")
+
+            for segmentation in row["annotations"]["segmentation"]:
+                polygon = polygon_from_segmentation(segmentation)
+                if polygon is None:
+                    continue
+                records.append({
+                    "image_path": image_path,
+                    "geometry": polygon.wkt,
+                    "label": "tree",
+                    "source": SOURCE,
+                    "existing_split": existing_split,
+                })
+
+    annotations = gpd.GeoDataFrame(records)
+    annotations.to_csv(annotations_csv, index=False)
+    print(f"Saved {len(annotations)} polygons across "
+          f"{annotations['image_path'].nunique()} tiles to {annotations_csv}")
+    print(annotations["existing_split"].value_counts())
+    return annotations_csv
+
+
+if __name__ == "__main__":
+    download_selvamask()

--- a/data_prep/annotation_csvs.cfg
+++ b/data_prep/annotation_csvs.cfg
@@ -66,3 +66,4 @@
 /orange/ewhite/DeepForest/Zenodo_19695972/annotations.csv
 /orange/ewhite/DeepForest/Hickman2021/annotations.csv
 /orange/ewhite/DeepForest/Allen2025/Allen_et_al/crops/annotations_polygons.csv
+/orange/ewhite/DeepForest/SelvaMask/annotations.csv

--- a/data_prep/package_datasets.py
+++ b/data_prep/package_datasets.py
@@ -1163,7 +1163,7 @@ def run(version, base_dir, mask_source_dir=None, debug=False):
 
 
 if __name__ == "__main__":
-    version = "v0.17"
+    version = "v0.18"
     base_dir = "/orange/ewhite/web/public/MillionTrees/"
     mask_source_dir = "/orange/ewhite/DeepForest/tree_coverage_masks"
     debug = False

--- a/data_prep/source_completeness.csv
+++ b/data_prep/source_completeness.csv
@@ -40,3 +40,4 @@ source,complete
 "Bolhman 2008",True
 "OFO field 2025",True
 "Allen et al. 2025",True
+"SelvaMask",True

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -29,8 +29,8 @@
 
     ```bash
     pip install . -U
-    # Or, if using uv for development:
-    # uv sync --dev extra
+    # Or, if using uv for development (installs the `dev` dependency group):
+    # uv sync --group dev
     ```
 
 ## Documentation

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -78,6 +78,7 @@ released checkpoint with no MillionTrees training at all.
 | DeepForest | ✓ | 0.526 | 0.650 | <small>`uv run python training/boxes/train.py --split-scheme random`</small> |
 | DeepForest | ✗ | 0.407 | 0.731 | <small>`uv run python existing_models/deepforest/eval_boxes.py --split-scheme random`</small> |
 | SAM3 | ✗ | 0.190 | 0.608 | <small>`uv run python existing_models/sam3/eval_boxes.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| CanopyRS DINO Swin-L | ✗ | pending | pending | <small>`python existing_models/canopyrs/eval_boxes.py --device cuda --split-scheme random`</small> |
 
 ### Zero-shot
 
@@ -86,6 +87,7 @@ released checkpoint with no MillionTrees training at all.
 | DeepForest | ✓ | 0.535 | 0.908 | <small>`uv run python training/boxes/train.py --split-scheme zeroshot`</small> |
 | DeepForest | ✗ | 0.432 | 0.962 | <small>`uv run python existing_models/deepforest/eval_boxes.py --split-scheme zeroshot`</small> |
 | SAM3 | ✗ | 0.209 | 0.798 | <small>`uv run python existing_models/sam3/eval_boxes.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
+| CanopyRS DINO Swin-L | ✗ | pending | pending | <small>`python existing_models/canopyrs/eval_boxes.py --device cuda --split-scheme zeroshot`</small> |
 
 ### Cross-geometry
 
@@ -110,6 +112,7 @@ SAM3 and detectree2.
 | Mask R-CNN | ✓ | 0.416 | 0.900 | <small>`uv run python training/polygons/train.py --split-scheme random`</small> |
 | detectree2 | ✗ | 0.304 | 0.891 | <small>`uv run python existing_models/detectree2/eval_polygons.py --split-scheme random`</small> |
 | SAM3 | ✗ | 0.186 | 0.619 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| CanopyRS DINO + SAM3 (SelvaMask) | ✗ | pending | pending | <small>`python existing_models/canopyrs/eval_polygons.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
 
 ### Zero-shot
 
@@ -118,6 +121,7 @@ SAM3 and detectree2.
 | detectree2 | ✗ | 0.375 | 0.945 | <small>`uv run python existing_models/detectree2/eval_polygons.py --split-scheme zeroshot`</small> |
 | SAM3 | ✗ | 0.165 | 0.663 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 | Mask R-CNN | ✓ | 0.064 | 0.814 | <small>`uv run python training/polygons/train.py --split-scheme zeroshot`</small> |
+| CanopyRS DINO + SAM3 (SelvaMask) | ✗ | pending | pending | <small>`python existing_models/canopyrs/eval_polygons.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 
 > **Note:** The Mask R-CNN ✓ zeroshot row is from the pre-fix polygon evaluator
 > (before GT-mask binarization / AP50; commit b2ff776) and is not directly comparable

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -39,7 +39,7 @@ generated from training checkpoints via `scripts/create_finetuned_visualizations
 
 Fine-tuned (✓) rows train on the MillionTrees train split (`training/points/train.py`);
 pretrained (✗) rows evaluate released weights on the test split (`existing_models/`).
-The TreeFormer point model needs `uv sync --extra treeformer` (DeepForest
+The TreeFormer point model needs `uv sync --group treeformer` (DeepForest
 [`treeformer-training`](https://github.com/jveitchmichaelis/DeepForest/tree/treeformer-training)
 branch until merged to main).
 
@@ -49,7 +49,7 @@ branch until merged to main).
 |---|:---:|---|---|---|
 | TreeFormer | ✗ | 56.435 | 0.775 | <small>`uv run python existing_models/treeformer/eval_points.py --split-scheme random`</small> |
 | SAM3 | ✗ | 54.593 | 0.711 | <small>`uv run python existing_models/sam3/eval_points.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
-| TreeFormer | ✓ | 57.461 | 0.784 | <small>`uv run --extra treeformer python training/points/train.py --split-scheme random`</small> |
+| TreeFormer | ✓ | 57.461 | 0.784 | <small>`uv run --group treeformer python training/points/train.py --split-scheme random`</small> |
 
 ### Zeroshot split
 
@@ -61,7 +61,7 @@ released checkpoint with no MillionTrees training at all.
 |---|:---:|---|---|---|
 | TreeFormer | ✗ | 15.717 | 0.882 | <small>`uv run python existing_models/treeformer/eval_points.py --split-scheme zeroshot`</small> |
 | SAM3 | ✗ | 14.878 | 0.759 | <small>`uv run python existing_models/sam3/eval_points.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
-| TreeFormer | ✓ | 17.024 | 0.869 | <small>`uv run --extra treeformer python training/points/train.py --split-scheme zeroshot`</small> |
+| TreeFormer | ✓ | 17.024 | 0.869 | <small>`uv run --group treeformer python training/points/train.py --split-scheme zeroshot`</small> |
 
 ### Cross-geometry
 

--- a/docs/repository_structure.md
+++ b/docs/repository_structure.md
@@ -51,6 +51,7 @@ dependencies stay isolated from the core package.
 | DeepForest | `existing_models/deepforest/` | boxes |
 | TreeFormer | `existing_models/treeformer/` | points |
 | SAM3 | `existing_models/sam3/` | boxes, points, polygons |
+| CanopyRS (DINO Swin-L / DINO+SAM3) | `existing_models/canopyrs/` | boxes, polygons |
 
 ```bash
 uv run python existing_models/deepforest/eval_boxes.py --split-scheme zeroshot --root-dir "$MT_ROOT"
@@ -79,7 +80,7 @@ uv run python scripts/make_benchmark_table.py --splits random zeroshot
 independently:
 
 - `training/slurm/submit_all_training.sh` → `train_boxes.sbatch`, `train_points.sbatch`, `train_polygons.sbatch`
-- `existing_models/slurm/submit_all_eval.sh` → `eval_deepforest.sbatch`, `eval_treeformer.sbatch`, `eval_sam3.sbatch`
+- `existing_models/slurm/submit_all_eval.sh` → `eval_deepforest.sbatch`, `eval_treeformer.sbatch`, `eval_sam3.sbatch`, `eval_canopyrs.sbatch`
 
 For a dependency-chained run that automatically rebuilds the table once every job
 finishes, use `slurm/run_benchmark.sbatch` instead.

--- a/docs/repository_structure.md
+++ b/docs/repository_structure.md
@@ -33,8 +33,8 @@ The point model needs the TreeFormer extra (DeepForest
 branch until it merges to weecology main):
 
 ```bash
-uv sync --extra treeformer
-uv run --extra treeformer python training/points/train.py --split-scheme random
+uv sync --group treeformer
+uv run --group treeformer python training/points/train.py --split-scheme random
 ```
 
 Each run writes `training/<geometry>/outputs/<split>/results_<split>.txt` (+ `.json`),
@@ -101,7 +101,7 @@ Each figure has two rows (**random**, **zeroshot** fine-tuning tasks) and two co
 (ground truth vs fine-tuned prediction on the same test image).
 
 ```bash
-uv run --extra treeformer python scripts/create_finetuned_visualizations.py \
+uv run --group treeformer python scripts/create_finetuned_visualizations.py \
   --root-dir "$MT_ROOT" \
   --output-dir docs \
   --panel-dir docs/figures/finetuned_panels

--- a/existing_models/canopyrs/README.md
+++ b/existing_models/canopyrs/README.md
@@ -1,0 +1,53 @@
+# CanopyRS baselines
+
+Pretrained tropical tree-crown baselines from the SelvaBox / SelvaMask papers
+([CanopyRS](https://github.com/hugobaudchon/CanopyRS)), evaluated on the MillionTrees
+test split.
+
+| Script | Task | Weights |
+|---|---|---|
+| `eval_boxes.py` | TreeBoxes | [`CanopyRS/dino-swin-l-384-multi-NQOS`](https://huggingface.co/CanopyRS/dino-swin-l-384-multi-NQOS) (DINO Swin-L, multi-resolution multi-dataset) |
+| `eval_polygons.py` | TreePolygons | [`CanopyRS/dino-swin-l-384-multi-NQOS-selvamask-FT`](https://huggingface.co/CanopyRS/dino-swin-l-384-multi-NQOS-selvamask-FT) detector + SelvaMask fine-tuned SAM 3 segmenter |
+
+The detector proposes crown boxes; for polygons SAM 3 turns each box into an instance
+mask (the SelvaMask segmentation pipeline). Both run through CanopyRS' own model
+wrappers, driven per image over the MillionTrees test loader.
+
+## Setup
+
+CanopyRS depends on detrex + Detectron2, which must be built from source, so this folder
+cannot be provisioned with a plain `uv sync`. Install CanopyRS first (its conda recipe is
+the supported path), then install MillionTrees into the same environment:
+
+```bash
+# 1. Install CanopyRS per its installation guide:
+#    https://hugobaudchon.github.io/CanopyRS/getting-started/installation/
+git clone https://github.com/hugobaudchon/CanopyRS.git
+cd CanopyRS
+conda create -n canopyrs -c conda-forge python=3.10 mamba && conda activate canopyrs
+mamba install gdal=3.6.2 -c conda-forge
+pip install torch==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu126
+git submodule update --init --recursive
+pip install -e .
+pip install --no-build-isolation -e ./detrex/detectron2 -e ./detrex
+# SAM 3 is required for eval_polygons.py and needs transformers>=5.0.0rc1
+pip install "transformers>=5.0.0rc1"
+
+# 2. Install MillionTrees into the same env
+pip install -e /path/to/MillionTrees
+```
+
+SAM 3 (`facebook/sam3`) is gated: request access on the model page and
+`huggingface-cli login` (or pass `--hf-token`) before running `eval_polygons.py`.
+
+## Run
+
+```bash
+python eval_boxes.py    --split-scheme random   --device cuda --output-dir outputs/random
+python eval_polygons.py --split-scheme random   --device cuda --output-dir outputs/random --hf-token "$HF_TOKEN"
+```
+
+Add `--viz-dir <dir>` for per-source prediction overlays, `--mini` for a smoke test, and
+`--split-scheme zeroshot` for the held-out-source task. Results are written to
+`outputs/<split>/results_<geometry>_<split>.{txt,json}`, which
+`scripts/make_benchmark_table.py` reads to regenerate the leaderboard.

--- a/existing_models/canopyrs/eval_boxes.py
+++ b/existing_models/canopyrs/eval_boxes.py
@@ -1,0 +1,111 @@
+"""Evaluate the CanopyRS DINO Swin-L detector on MillionTrees TreeBoxes.
+
+Uses the multi-resolution, multi-dataset detector released with the SelvaBox paper
+(https://huggingface.co/CanopyRS/dino-swin-l-384-multi-NQOS). The model is loaded
+through CanopyRS' own detrex/Detectron2 wrapper; we feed it the MillionTrees test
+images batch by batch and convert its boxes to the MillionTrees evaluation format.
+
+CanopyRS (with detrex + Detectron2) must be installed in the environment; see
+README.md for setup.
+"""
+
+import argparse
+import json
+import os
+from typing import List
+
+import numpy as np
+import torch
+
+from milliontrees import get_dataset
+from milliontrees.common.data_loaders import get_eval_loader
+
+DETECTOR_CONFIG = "detectors/dino_swinL_multi_NQOS.yaml"
+MODEL_NAME = "CanopyRS-DINO-SwinL"
+
+
+def select_device(device_arg: str) -> torch.device:
+    if device_arg == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device_arg)
+
+
+def load_detector(config_name: str):
+    """Instantiate the CanopyRS detrex detector wrapper from a bundled config."""
+    from canopyrs.engine.config_parsers import DetectorConfig
+    from canopyrs.engine.config_parsers.base import get_config_path
+    from canopyrs.engine.models.detector.detectron2_infer import Detectron2DetectorWrapper
+
+    config = DetectorConfig.from_yaml(get_config_path(config_name))
+    config.batch_size = 1
+    return Detectron2DetectorWrapper(config)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CanopyRS DINO on TreeBoxes.")
+    parser.add_argument("--root-dir", type=str,
+                        default=os.environ.get("MT_ROOT", "/orange/ewhite/web/public/MillionTrees"))
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--mini", action="store_true")
+    parser.add_argument("--download", action="store_true")
+    parser.add_argument("--split-scheme", type=str, default="random",
+                        choices=["random", "zeroshot", "crossgeometry"])
+    parser.add_argument("--device", type=str, default="auto", choices=["auto", "cpu", "cuda"])
+    parser.add_argument("--score-threshold", type=float, default=0.2)
+    parser.add_argument("--max-batches", type=int, default=None)
+    parser.add_argument("--output-dir", type=str, default=None)
+    parser.add_argument("--viz-dir", type=str, default=None,
+                        help="Directory for per-source prediction overlay PNGs")
+    args = parser.parse_args()
+
+    device = select_device(args.device)
+    detector = load_detector(DETECTOR_CONFIG)
+
+    dataset = get_dataset("TreeBoxes", root_dir=args.root_dir, download=args.download,
+                          mini=args.mini, split_scheme=args.split_scheme)
+    test_subset = dataset.get_subset("test")
+    test_loader = get_eval_loader("standard", test_subset, batch_size=args.batch_size,
+                                  num_workers=args.num_workers)
+
+    print(f"Batches: {len(test_loader)}")
+
+    all_y_pred, all_y_true = [], []
+    for b_idx, (metadata, images, targets) in enumerate(test_loader):
+        image_list: List[torch.Tensor] = [img.to(device) for img in images]
+        preds = detector.forward(image_list)
+
+        for pred, target in zip(preds, targets):
+            boxes = pred["boxes"].float().cpu()
+            scores = pred["scores"].float().cpu()
+            keep = scores >= args.score_threshold
+            boxes, scores = boxes[keep], scores[keep]
+            all_y_pred.append({
+                "y": boxes,
+                "labels": torch.zeros(boxes.shape[0], dtype=torch.int64),
+                "scores": scores,
+            })
+            all_y_true.append(target)
+
+        if args.max_batches is not None and (b_idx + 1) >= args.max_batches:
+            break
+
+    results, results_str = dataset.eval(
+        all_y_pred, all_y_true, test_subset.metadata_array[:len(all_y_true)],
+        viz_dir=args.viz_dir,
+    )
+    print(results_str)
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        with open(os.path.join(args.output_dir, f"results_boxes_{args.split_scheme}.txt"), "w") as f:
+            f.write(results_str)
+        flat = {k: float(v) if hasattr(v, "item") else v
+                for k, v in results.items() if isinstance(v, (int, float, torch.Tensor))}
+        with open(os.path.join(args.output_dir, f"results_boxes_{args.split_scheme}.json"), "w") as f:
+            json.dump({"model": MODEL_NAME, "task": "TreeBoxes",
+                       "split": args.split_scheme, "metrics": flat}, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/existing_models/canopyrs/eval_polygons.py
+++ b/existing_models/canopyrs/eval_polygons.py
@@ -1,0 +1,174 @@
+"""Evaluate the CanopyRS SelvaMask pipeline on MillionTrees TreePolygons.
+
+Reproduces the SelvaMask instance-segmentation baseline: the SelvaMask fine-tuned
+DINO Swin-L detector
+(https://huggingface.co/CanopyRS/dino-swin-l-384-multi-NQOS-selvamask-FT) proposes
+crown boxes, and a (SelvaMask fine-tuned) SAM 3 segmenter turns each box into an
+instance mask. Detector boxes and SAM 3 segmentation both run through CanopyRS' own
+model wrappers; we drive them per image on the MillionTrees test set and convert the
+masks to the MillionTrees evaluation format.
+
+CanopyRS (detrex + Detectron2) and gated access to ``facebook/sam3`` are required;
+see README.md.
+"""
+
+import argparse
+import json
+import os
+from typing import List
+
+import numpy as np
+import torch
+from PIL import Image
+
+from milliontrees import get_dataset
+from milliontrees.common.data_loaders import get_eval_loader
+
+DETECTOR_CONFIG = "detectors/dino_swinL_multi_NQOS_selvamask_FT.yaml"
+SEGMENTER_CONFIG = "segmenters/sam3_multi_selvamask_FT.yaml"
+MODEL_NAME = "CanopyRS-DINO-SAM3-SelvaMask"
+
+
+def select_device(device_arg: str) -> torch.device:
+    if device_arg == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device_arg)
+
+
+def load_detector(config_name: str):
+    from canopyrs.engine.config_parsers import DetectorConfig
+    from canopyrs.engine.config_parsers.base import get_config_path
+    from canopyrs.engine.models.detector.detectron2_infer import Detectron2DetectorWrapper
+
+    config = DetectorConfig.from_yaml(get_config_path(config_name))
+    config.batch_size = 1
+    return Detectron2DetectorWrapper(config)
+
+
+def load_segmenter(config_name: str):
+    from canopyrs.engine.config_parsers import SegmenterConfig
+    from canopyrs.engine.config_parsers.base import get_config_path
+    from canopyrs.engine.models.segmenter.sam3 import Sam3PredictorWrapper
+
+    config = SegmenterConfig.from_yaml(get_config_path(config_name))
+    return Sam3PredictorWrapper(config)
+
+
+def image_to_pil(image: torch.Tensor) -> Image.Image:
+    array = (image.permute(1, 2, 0).clamp(0, 1).cpu().numpy() * 255).astype(np.uint8)
+    return Image.fromarray(array).convert("RGB")
+
+
+def segment_boxes(segmenter, pil_image: Image.Image, boxes: np.ndarray):
+    """Return ((N, H, W) uint8 masks, (N,) validity mask) for the given xyxy boxes.
+
+    Masks are produced one per input box (batched by ``box_batch_size``); degenerate
+    boxes get an all-zero mask and are flagged ``False`` in the validity mask.
+    """
+    width, height = pil_image.size
+    boxes = boxes.astype(np.float32).copy()
+    boxes[:, [0, 2]] = boxes[:, [0, 2]].clip(0, width)
+    boxes[:, [1, 3]] = boxes[:, [1, 3]].clip(0, height)
+    valid = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+
+    masks = np.zeros((boxes.shape[0], height, width), dtype=np.uint8)
+    valid_boxes = boxes[valid]
+    if len(valid_boxes) == 0:
+        return masks, valid
+
+    batch_size = segmenter.config.box_batch_size or len(valid_boxes)
+    predicted = []
+    for start in range(0, len(valid_boxes), batch_size):
+        batch_masks, _ = segmenter._predict_batch(pil_image, valid_boxes[start:start + batch_size])
+        predicted.append(batch_masks)
+    masks[valid] = np.concatenate(predicted, axis=0)
+    return masks, valid
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CanopyRS DINO + SAM3 on TreePolygons.")
+    parser.add_argument("--root-dir", type=str,
+                        default=os.environ.get("MT_ROOT", "/orange/ewhite/web/public/MillionTrees"))
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--mini", action="store_true")
+    parser.add_argument("--download", action="store_true")
+    parser.add_argument("--split-scheme", type=str, default="random",
+                        choices=["random", "zeroshot", "crossgeometry"])
+    parser.add_argument("--device", type=str, default="auto", choices=["auto", "cpu", "cuda"])
+    parser.add_argument("--score-threshold", type=float, default=0.2)
+    parser.add_argument("--image-size", type=int, default=1024)
+    parser.add_argument("--hf-token", type=str, default=os.environ.get("HF_TOKEN"))
+    parser.add_argument("--max-batches", type=int, default=None)
+    parser.add_argument("--output-dir", type=str, default=None)
+    parser.add_argument("--viz-dir", type=str, default=None,
+                        help="Directory for per-source prediction overlay PNGs")
+    args = parser.parse_args()
+
+    device = select_device(args.device)
+    detector = load_detector(DETECTOR_CONFIG)
+    segmenter = load_segmenter(SEGMENTER_CONFIG)
+
+    dataset = get_dataset("TreePolygons", root_dir=args.root_dir, download=args.download,
+                          mini=args.mini, split_scheme=args.split_scheme,
+                          image_size=args.image_size)
+    test_subset = dataset.get_subset("test")
+    test_loader = get_eval_loader("standard", test_subset, batch_size=args.batch_size,
+                                  num_workers=args.num_workers)
+
+    print(f"Batches: {len(test_loader)}")
+
+    all_y_pred, all_y_true = [], []
+    for b_idx, (metadata, images, targets) in enumerate(test_loader):
+        image_list: List[torch.Tensor] = [img.to(device) for img in images]
+        preds = detector.forward(image_list)
+
+        for img, pred, target in zip(images, preds, targets):
+            boxes = pred["boxes"].float().cpu()
+            scores = pred["scores"].float().cpu()
+            keep = scores >= args.score_threshold
+            boxes, scores = boxes[keep], scores[keep]
+
+            height, width = img.shape[-2], img.shape[-1]
+            if boxes.shape[0] == 0:
+                all_y_pred.append({
+                    "y": torch.zeros((0, height, width), dtype=torch.uint8),
+                    "labels": torch.zeros((0,), dtype=torch.int64),
+                    "scores": torch.zeros((0,), dtype=torch.float32),
+                })
+                all_y_true.append(target)
+                continue
+
+            pil_image = image_to_pil(img)
+            masks, valid = segment_boxes(segmenter, pil_image, boxes.numpy())
+            masks = torch.from_numpy(masks).to(torch.uint8)
+            scores = scores * torch.from_numpy(valid.astype(np.float32))
+            all_y_pred.append({
+                "y": masks,
+                "labels": torch.zeros(masks.shape[0], dtype=torch.int64),
+                "scores": scores,
+            })
+            all_y_true.append(target)
+
+        if args.max_batches is not None and (b_idx + 1) >= args.max_batches:
+            break
+
+    results, results_str = dataset.eval(
+        all_y_pred, all_y_true, metadata=test_subset.metadata_array[:len(all_y_true)],
+        viz_dir=args.viz_dir,
+    )
+    print(results_str)
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        with open(os.path.join(args.output_dir, f"results_polygons_{args.split_scheme}.txt"), "w") as f:
+            f.write(results_str)
+        flat = {k: float(v) if hasattr(v, "item") else v
+                for k, v in results.items() if isinstance(v, (int, float, torch.Tensor))}
+        with open(os.path.join(args.output_dir, f"results_polygons_{args.split_scheme}.json"), "w") as f:
+            json.dump({"model": MODEL_NAME, "task": "TreePolygons",
+                       "split": args.split_scheme, "metrics": flat}, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/existing_models/canopyrs/pyproject.toml
+++ b/existing_models/canopyrs/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "milliontrees-canopyrs"
+version = "0.1.0"
+description = "CanopyRS DINO Swin-L (SelvaBox) and DINO + SAM3 (SelvaMask) baselines on MillionTrees"
+requires-python = ">=3.10,<3.11"
+dependencies = [
+    "milliontrees",
+    "canopyrs",
+    "transformers>=5.0.0rc1",
+    "huggingface-hub>=1.0.0",
+]
+
+[tool.uv.sources]
+milliontrees = { path = "../..", editable = true }
+
+# NOTE: CanopyRS pulls in detrex + Detectron2, which must be built from source and
+# cannot be resolved by pip/uv alone. Follow the CanopyRS installation guide and
+# install milliontrees into that environment instead of using `uv sync` here. See
+# README.md.

--- a/existing_models/slurm/eval_canopyrs.sbatch
+++ b/existing_models/slurm/eval_canopyrs.sbatch
@@ -1,0 +1,45 @@
+#!/bin/bash
+#SBATCH --job-name=mt_eval_canopyrs
+#SBATCH --output=/home/b.weinstein/logs/%x_%A_%a.out
+#SBATCH --error=/home/b.weinstein/logs/%x_%A_%a.err
+#SBATCH --array=0-1
+#SBATCH --time=24:00:00
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=100G
+#SBATCH --partition=hpg-turin
+#SBATCH --gpus=1
+
+set -euo pipefail
+
+REPO=/blue/ewhite/b.weinstein/src/MillionTrees
+ROOT_DIR=${MT_ROOT:-/orange/ewhite/web/public/MillionTrees}
+SPLITS=(random zeroshot)
+SPLIT=${SPLITS[$SLURM_ARRAY_TASK_ID]}
+OUT_BASE=$REPO/existing_models/canopyrs/outputs/$SPLIT
+
+# CanopyRS (detrex + Detectron2 + SAM3) lives in its own conda env; see README.md.
+CANOPYRS_ENV=${CANOPYRS_ENV:-canopyrs}
+source "$(conda info --base)/etc/profile.d/conda.sh"
+conda activate "$CANOPYRS_ENV"
+
+cd $REPO/existing_models/canopyrs
+
+echo "=== CanopyRS eval: split=$SPLIT ==="
+
+python eval_boxes.py \
+  --root-dir "$ROOT_DIR" \
+  --split-scheme "$SPLIT" \
+  --device cuda \
+  --batch-size 4 \
+  --output-dir "$OUT_BASE" \
+  --viz-dir "$OUT_BASE/viz_boxes"
+
+python eval_polygons.py \
+  --root-dir "$ROOT_DIR" \
+  --split-scheme "$SPLIT" \
+  --device cuda \
+  --batch-size 2 \
+  --output-dir "$OUT_BASE" \
+  --viz-dir "$OUT_BASE/viz_polygons"
+
+echo "=== CanopyRS eval done. Results in $OUT_BASE ==="

--- a/existing_models/slurm/submit_all_eval.sh
+++ b/existing_models/slurm/submit_all_eval.sh
@@ -16,4 +16,7 @@ sbatch existing_models/slurm/eval_sam3.sbatch
 echo "Submitting Detectree2 (pretrained polygon model) evaluation..."
 sbatch existing_models/slurm/eval_detectree2.sbatch
 
+echo "Submitting CanopyRS (DINO boxes + DINO/SAM3 polygons) evaluation..."
+sbatch existing_models/slurm/eval_canopyrs.sbatch
+
 echo "All eval jobs submitted."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,24 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# docs stays an installable extra because ReadTheDocs (.readthedocs.yaml) pulls it
+# via pip extra_requirements, and it has no direct-URL deps to break PyPI uploads.
+docs = [
+    "sphinx",
+    "furo",
+    "sphinx_markdown_tables",
+    "myst_parser",
+    "sphinx_rtd_theme",
+    "sphinx-design",
+    "nbmake",
+    "nbsphinx",
+    "nbqa",
+]
+
+# PEP 735 dependency groups are never written into the published wheel/sdist
+# metadata, so the deepforest git+https refs below stay out of the PyPI upload
+# and `pip install milliontrees` users don't pull the dev/analysis stack.
+[dependency-groups]
 dev = [
     "pytest",
     "bumpversion",
@@ -86,17 +104,6 @@ treeformer = [
     "deepforest @ git+https://github.com/jveitchmichaelis/DeepForest.git@treeformer-training",
     "geopandas",
     "comet-ml>=3.44.4",
-]
-docs = [
-    "sphinx",
-    "furo",
-    "sphinx_markdown_tables",
-    "myst_parser",
-    "sphinx_rtd_theme",
-    "sphinx-design",
-    "nbmake",
-    "nbsphinx",
-    "nbqa",
 ]
 
 [tool.setuptools]

--- a/scripts/make_benchmark_table.py
+++ b/scripts/make_benchmark_table.py
@@ -81,6 +81,8 @@ def find_existing_model_results(split: str) -> List[Dict]:
         ("deepforest", "DeepForest-pretrained"): ["boxes"],
         ("treeformer", "TreeFormer-pretrained"): ["points"],
         ("sam3", "SAM3"): ["boxes", "points", "polygons"],
+        ("canopyrs", "CanopyRS-DINO-SwinL"): ["boxes"],
+        ("canopyrs", "CanopyRS-DINO-SAM3-SelvaMask"): ["polygons"],
     }
     for (model_dir, model_name), task_keys in model_tasks.items():
         for task_key in task_keys:

--- a/slurm/filter_auto_arborist_tcd.sbatch
+++ b/slurm/filter_auto_arborist_tcd.sbatch
@@ -15,7 +15,7 @@ set -euo pipefail
 cd /blue/ewhite/b.weinstein/src/MillionTrees
 mkdir -p logs/slurm
 
-uv sync --extra dev
+uv sync --group dev
 
 ANNOTATIONS_CSV="/orange/ewhite/DeepForest/AutoArborist/downloaded_imagery/AutoArborist_combined_annotations.csv"
 OUTPUT_CSV="/orange/ewhite/DeepForest/AutoArborist/downloaded_imagery/AutoArborist_combined_annotations_tcd_filtered.csv"

--- a/slurm/submit_neon_unsupervised.sh
+++ b/slurm/submit_neon_unsupervised.sh
@@ -11,7 +11,7 @@
 #SBATCH --error=/home/b.weinstein/logs/neon_unsupervised_%j.err
 
 # Use uv for Python environment management
-uv sync --extra dev
+uv sync --group dev
 
 # Set working directory
 cd /blue/ewhite/b.weinstein/src/MillionTrees/data_prep

--- a/slurm/submit_ofo_field.sh
+++ b/slurm/submit_ofo_field.sh
@@ -10,7 +10,7 @@
 #SBATCH --output=/home/b.weinstein/logs/ofo_field_%j.out
 #SBATCH --error=/home/b.weinstein/logs/ofo_field_%j.err
 
-uv sync --extra dev
+uv sync --group dev
 
 cd /blue/ewhite/b.weinstein/src/MillionTrees/data_prep
 

--- a/slurm/submit_ofo_unsupervised.sh
+++ b/slurm/submit_ofo_unsupervised.sh
@@ -10,7 +10,7 @@
 #SBATCH --output=/home/b.weinstein/logs/ofo_unsupervised_%j.out
 #SBATCH --error=/home/b.weinstein/logs/ofo_unsupervised_%j.err
 
-uv sync --extra dev
+uv sync --group dev
 
 # Set working directory
 cd /blue/ewhite/b.weinstein/src/MillionTrees/data_prep

--- a/slurm/visualize_finetuned.sbatch
+++ b/slurm/visualize_finetuned.sbatch
@@ -16,8 +16,8 @@ cd "$REPO"
 
 echo "=== Fine-tuned panel figures (random + zeroshot) ==="
 
-# TreeFormer point checkpoints need the treeformer DeepForest extra.
-uv run --extra treeformer python scripts/create_finetuned_visualizations.py \
+# TreeFormer point checkpoints need the treeformer DeepForest group.
+uv run --group treeformer python scripts/create_finetuned_visualizations.py \
   --root-dir "$ROOT_DIR" \
   --output-dir "$REPO/docs" \
   --panel-dir "$REPO/docs/figures/finetuned_panels" \

--- a/training/points/README.md
+++ b/training/points/README.md
@@ -3,18 +3,18 @@
 Fine-tunes the native [DeepForest TreeFormer](https://github.com/jveitchmichaelis/DeepForest/tree/treeformer-training)
 point model (PvT backbone + density / OT losses) on the MillionTrees train split.
 
-Install the TreeFormer extra (DeepForest `treeformer-training` branch until it merges
-to weecology main):
+Install the TreeFormer dependency group (DeepForest `treeformer-training` branch until it
+merges to weecology main):
 
 ```bash
-uv sync --extra treeformer
+uv sync --group treeformer
 ```
 
 Train on the **train** split and evaluate on **test** (`random` or `zeroshot`; zeroshot
 holds out entire source datasets from train but still fine-tunes on the rest):
 
 ```bash
-uv run --extra treeformer python training/points/train.py \
+uv run --group treeformer python training/points/train.py \
   --split-scheme zeroshot \
   --root-dir "$MT_ROOT"
 ```
@@ -22,7 +22,7 @@ uv run --extra treeformer python training/points/train.py \
 Evaluate a saved Lightning checkpoint:
 
 ```bash
-uv run --extra treeformer python training/points/eval.py \
+uv run --group treeformer python training/points/eval.py \
   --checkpoint training/points/outputs/zeroshot/checkpoints/treeformer-epoch=19-val_loss=0.1234.ckpt \
   --split-scheme zeroshot
 ```
@@ -30,5 +30,5 @@ uv run --extra treeformer python training/points/eval.py \
 The pretrained (no fine-tuning) TreeFormer baseline lives in
 `existing_models/treeformer/eval_points.py`. SLURM training: `training/slurm/train_points.sbatch`.
 
-When point training lands on `weecology/DeepForest` main, drop the git extra and use the
-released `deepforest` from PyPI.
+When point training lands on `weecology/DeepForest` main, drop the git dependency group and
+use the released `deepforest` from PyPI.

--- a/training/points/train.py
+++ b/training/points/train.py
@@ -7,7 +7,7 @@ sources).
 
 Uses the point-detection stack from the DeepForest ``treeformer-training`` branch
 (https://github.com/jveitchmichaelis/DeepForest/tree/treeformer-training).
-Install with ``uv sync --extra treeformer`` until this lands on weecology/DeepForest main.
+Install with ``uv sync --group treeformer`` until this lands on weecology/DeepForest main.
 """
 
 import argparse

--- a/training/slurm/train_points.sbatch
+++ b/training/slurm/train_points.sbatch
@@ -21,8 +21,8 @@ SPLITS=(random zeroshot)
 SPLIT=${SPLITS[$SLURM_ARRAY_TASK_ID]}
 
 # TreeFormer point model lives on the DeepForest treeformer-training branch;
-# --extra treeformer pulls it in (see pyproject.toml).
-srun uv run --extra treeformer python training/points/train.py \
+# --group treeformer pulls it in (see pyproject.toml).
+srun uv run --group treeformer python training/points/train.py \
   --root-dir "$ROOT_DIR" \
   --split-scheme "$SPLIT" \
   --batch-size 8 \


### PR DESCRIPTION
## Summary
- Add `data_prep/SelvaMask.py` to fetch the [SelvaMask](https://huggingface.co/datasets/selvamask/SelvaMask) tropical tree-crown segmentation dataset from HuggingFace parquet shards, save RGB PNG tiles, and emit COCO polygon segmentations as WKT polygons in image (pixel) coordinates (top-left origin), matching the MillionTrees annotation format.
- Preserve the published parquet split via `existing_split`: HF `test` -> `test`, and HF `train` + `validation` -> `train` (MillionTrees carries only a train/test split; validation is an intermediate set folded into train).
- Register the dataset under `[TreePolygons]` in `annotation_csvs.cfg`, mark `SelvaMask` as `complete=True` in `source_completeness.csv`, and bump packaging to `v0.18` in `package_datasets.py`.

## Details
- The HF dataset exposes `annotations.segmentation` as COCO rings in pixel coordinates; we take the exterior ring per crown and build a shapely `Polygon`. Non-polygon / <3-vertex entries are skipped (and the packaging pipeline further drops degenerate polygons).
- Output: `/orange/ewhite/DeepForest/SelvaMask/annotations.csv` with `image_path`, `geometry`, `label`, `source`, `existing_split`; tiles written to `images/`.

## Test plan
- [x] `polygon_from_segmentation` validated against a real `train` sample row (302/302 annotations parse as simple polygons in pixel WKT).
- [x] `uv run pre-commit run --all-files` passes (yapf, docformatter).
- [ ] Run `python data_prep/SelvaMask.py` on the data host (requires `/orange` + network) to materialize tiles + `annotations.csv`.
- [ ] Run `data_prep/package_datasets.py` to build the `v0.18` TreePolygons release including SelvaMask.

Made with [Cursor](https://cursor.com)