### PR TITLE
Enforce unsupervised labeling, dedup annotations, refresh leaderboard

### DIFF
--- a/data_prep/package_datasets.py
+++ b/data_prep/package_datasets.py
@@ -43,6 +43,86 @@ ZEROSHOT_TEST_SOURCES_BOXES = [
     "NEON_benchmark",
 ]
 
+# Canonical token that marks a source as unsupervised/weakly-labeled. The data
+# loader excludes these by default via exclude_sources=['*unsupervised*'].
+UNSUPERVISED_SUFFIX = "unsupervised"
+
+# Sources that are unsupervised/weakly-labeled but whose upstream annotation CSVs
+# can ship WITHOUT the canonical suffix (e.g. SPREAD's "Feng et al. 2025" when
+# data_prep/SPREAD.py has not been re-run). normalize_unsupervised_sources()
+# rewrites these to "<name> unsupervised" at packaging time so the label is
+# permanent in every released CSV and the loader's '*unsupervised*' exclusion
+# always catches them. This is the single source of truth — add a source here
+# instead of sprinkling per-source masks through the splitting code.
+UNSUPERVISED_SOURCE_ALIASES = {
+    "Feng et al. 2025",
+}
+
+
+def normalize_unsupervised_sources(datasets):
+    """Force every known-unsupervised source name to carry the canonical suffix.
+
+    Idempotent: a source that already contains 'unsupervised' or 'weak supervised'
+    (case-insensitive) is left unchanged; declared aliases get ' unsupervised'
+    appended exactly once. Run this immediately after loading/combining so all
+    downstream splitting, filtering, and the published CSVs see the correct name.
+    """
+    if "source" not in datasets.columns:
+        return datasets
+    src = datasets["source"].astype(str)
+    already = src.str.contains("unsupervised|weak supervised", case=False, na=False)
+    alias = src.isin(UNSUPERVISED_SOURCE_ALIASES) & ~already
+    if alias.any():
+        renamed = sorted(src[alias].unique())
+        datasets.loc[alias, "source"] = src[alias] + f" {UNSUPERVISED_SUFFIX}"
+        print(f"Relabeled unsupervised sources (added '{UNSUPERVISED_SUFFIX}'): {renamed}")
+    return datasets
+
+
+# Canonical full names of every unsupervised/weakly-labeled source we ship, per
+# geometry. verify_unsupervised_sources() checks these survived packaging: it
+# fails loudly if a base name shows up WITHOUT the 'unsupervised' suffix (the
+# SPREAD/Feng regression). Unlike UNSUPERVISED_SOURCE_ALIASES it does NOT rename
+# anything, so listing a source whose base also has a supervised variant (e.g.
+# the NEON 'Weinstein et al. 2018' box benchmark) is safe.
+UNSUPERVISED_SOURCES_EXPECTED = {
+    "TreePolygons": ["Feng et al. 2025 unsupervised"],
+    "TreePoints": ["Young et al. 2025 unsupervised"],
+    "TreeBoxes": ["Weinstein et al. 2018 unsupervised"],
+}
+
+
+def verify_unsupervised_sources(datasets, dataset_type):
+    """Verify expected unsupervised sources kept their canonical suffix.
+
+    Turns a silent labeling regression (an unsupervised source shipping without
+    the 'unsupervised' suffix, as SPREAD/Feng did) into a hard failure at
+    packaging time. Does not modify the data.
+    """
+    expected = UNSUPERVISED_SOURCES_EXPECTED.get(dataset_type, [])
+    if not expected or "source" not in datasets.columns:
+        return
+    present = set(datasets["source"].astype(str).unique())
+    present_lower = {s.lower() for s in present}
+    problems = []
+    for canonical in expected:
+        base = canonical.lower()
+        if base.endswith(UNSUPERVISED_SUFFIX):
+            base = base[: -len(UNSUPERVISED_SUFFIX)].strip()
+        # The bare (un-suffixed) base name must not appear as its own source.
+        if base in present_lower:
+            problems.append(
+                f"{base!r} is present without the '{UNSUPERVISED_SUFFIX}' suffix "
+                f"(expected {canonical!r}) -- add it to UNSUPERVISED_SOURCE_ALIASES"
+            )
+        elif canonical not in present:
+            # Not fatal: a sub-release (Mini/Small) may legitimately drop it.
+            print(f"Note: expected unsupervised source {canonical!r} not present in {dataset_type}")
+    if problems:
+        raise ValueError(
+            f"{dataset_type}: unsupervised labeling regression -> " + "; ".join(problems)
+        )
+
 def remove_alpha_channel(datasets):
     """Remove alpha channels from images in the dataset."""
     for source in datasets["source"].unique():
@@ -232,6 +312,26 @@ def filter_degenerate_polygons(datasets):
         print(f"Filtered out {n_filtered} degenerate polygons (zero width or height)")
     
     return datasets.loc[valid_mask].copy()
+
+
+def drop_duplicate_annotations(datasets, label=""):
+    """Drop exact duplicate annotations (same image + geometry + source).
+
+    Upstream prediction CSVs have shipped the same box/point/polygon multiple
+    times (differing only in columns the packager drops, such as prediction
+    confidence), which collapses into identical published rows and inflates
+    annotation counts. This removes those duplicates on the canonical identity.
+    """
+    key = [c for c in ("filename", "geometry", "source") if c in datasets.columns]
+    if not key or "geometry" not in datasets.columns:
+        return datasets
+    n_before = len(datasets)
+    datasets = datasets.drop_duplicates(subset=key).copy()
+    n_dropped = n_before - len(datasets)
+    if n_dropped > 0:
+        print(f"{label}: dropped {n_dropped} duplicate annotations "
+              f"({n_before} -> {len(datasets)})")
+    return datasets
 
 
 def create_directories(base_dir, dataset_type):
@@ -532,12 +632,13 @@ def random_split(TreePolygons_datasets, TreePoints_datasets, TreeBoxes_datasets,
     TreePoints_datasets = apply_split(TreePoints_datasets)
     TreeBoxes_datasets = apply_split(TreeBoxes_datasets)
 
-    # Remove from test split any entries with 'unsupervised' or 'weak supervised' in the source column or Feng source
+    # Remove from test split any entries with 'unsupervised' or 'weak supervised'
+    # in the source column. normalize_unsupervised_sources() guarantees aliases
+    # like SPREAD/Feng already carry the 'unsupervised' suffix, so a single
+    # substring check covers them.
     def remove_unsupervised_test_entries(df):
         if "split" in df.columns and "source" in df.columns:
-            unsupervised_mask = (df["split"] == "test") & (df["source"].str.contains("unsupervised|weak supervised", case=False, na=False))
-            feng_mask = (df["split"] == "test") & (df["source"] == "Feng et al. 2025")
-            mask = unsupervised_mask | feng_mask
+            mask = (df["split"] == "test") & (df["source"].str.contains("unsupervised|weak supervised", case=False, na=False))
             return df.loc[~mask]
         return df
 
@@ -593,18 +694,16 @@ def cross_geometry_split(TreePolygons_datasets, TreePoints_datasets, TreeBoxes_d
     TreeBoxes_datasets.loc[
         TreeBoxes_datasets["split"] != "validation", "split"] = "train"
 
-    # remove any source with unsupervised, weak supervised, or Feng from test
+    # remove any unsupervised / weak supervised source from test (aliases such as
+    # SPREAD/Feng are already suffixed by normalize_unsupervised_sources)
     unsupervised_mask_polygons = (TreePolygons_datasets.source.str.contains('unsupervised|weak supervised', case=False, na=False)) & (TreePolygons_datasets.split == "test")
-    feng_mask_polygons = (TreePolygons_datasets.source == "Feng et al. 2025") & (TreePolygons_datasets.split == "test")
-    TreePolygons_datasets = TreePolygons_datasets[~(unsupervised_mask_polygons | feng_mask_polygons)]
+    TreePolygons_datasets = TreePolygons_datasets[~unsupervised_mask_polygons]
 
     unsupervised_mask_points = (TreePoints_datasets.source.str.contains('unsupervised|weak supervised', case=False, na=False)) & (TreePoints_datasets.split == "test")
-    feng_mask_points = (TreePoints_datasets.source == "Feng et al. 2025") & (TreePoints_datasets.split == "test")
-    TreePoints_datasets = TreePoints_datasets[~(unsupervised_mask_points | feng_mask_points)]
+    TreePoints_datasets = TreePoints_datasets[~unsupervised_mask_points]
 
     unsupervised_mask_boxes = (TreeBoxes_datasets.source.str.contains('unsupervised|weak supervised', case=False, na=False)) & (TreeBoxes_datasets.split == "test")
-    feng_mask_boxes = (TreeBoxes_datasets.source == "Feng et al. 2025") & (TreeBoxes_datasets.split == "test")
-    TreeBoxes_datasets = TreeBoxes_datasets[~(unsupervised_mask_boxes | feng_mask_boxes)]
+    TreeBoxes_datasets = TreeBoxes_datasets[~unsupervised_mask_boxes]
 
     TreePolygons_datasets.to_csv(
         f"{base_dir}{prefix}TreePolygons{suffix}_{version}/crossgeometry.csv", index=False)
@@ -748,12 +847,12 @@ def zero_shot_split(TreePolygons_datasets, TreePoints_datasets, TreeBoxes_datase
         TreeBoxes_datasets, test_sources_boxes, excess_mode="drop"
     )
 
-    # Remove Feng, unsupervised, and weak supervised from test (shouldn't be there, but filter for safety)
+    # Move any unsupervised / weak supervised source out of test (shouldn't be
+    # there, but filter for safety). Aliases like SPREAD/Feng are already
+    # suffixed by normalize_unsupervised_sources, so one substring check covers them.
     def remove_feng_and_unsupervised_from_test(df):
         if "split" in df.columns and "source" in df.columns:
-            unsupervised_mask = (df["split"] == "test") & (df["source"].str.contains("unsupervised|weak supervised", case=False, na=False))
-            feng_mask = (df["split"] == "test") & (df["source"] == "Feng et al. 2025")
-            mask = unsupervised_mask | feng_mask
+            mask = (df["split"] == "test") & (df["source"].str.contains("unsupervised|weak supervised", case=False, na=False))
             if mask.any():
                 df.loc[mask, "split"] = "train"
         return df
@@ -904,6 +1003,18 @@ def run(version, base_dir, mask_source_dir=None, debug=False):
     TreePoints_datasets = combine_datasets(TreePoints, debug=debug)
     TreePolygons_datasets = combine_datasets(TreePolygons, debug=debug)
 
+    # Enforce canonical unsupervised source names up front so the label is baked
+    # into every released CSV (and caught by the loader's '*unsupervised*'
+    # exclusion) regardless of whether upstream generators were re-run.
+    TreeBoxes_datasets = normalize_unsupervised_sources(TreeBoxes_datasets)
+    TreePoints_datasets = normalize_unsupervised_sources(TreePoints_datasets)
+    TreePolygons_datasets = normalize_unsupervised_sources(TreePolygons_datasets)
+
+    # Fail loudly if any expected unsupervised source lost its suffix upstream.
+    verify_unsupervised_sources(TreeBoxes_datasets, "TreeBoxes")
+    verify_unsupervised_sources(TreePoints_datasets, "TreePoints")
+    verify_unsupervised_sources(TreePolygons_datasets, "TreePolygons")
+
     # Coerce box columns early (avoids mixed str/float rows) and drop degenerate rows
     for col in ("xmin", "ymin", "xmax", "ymax"):
         TreeBoxes_datasets[col] = pd.to_numeric(TreeBoxes_datasets[col], errors="coerce")
@@ -935,9 +1046,17 @@ def run(version, base_dir, mask_source_dir=None, debug=False):
 
     # Remove degenerate boxes (zero width/height) so albumentations does not raise
     TreeBoxes_datasets = filter_degenerate_boxes(TreeBoxes_datasets)
-    
+
     # Remove degenerate polygons (those that would create invalid bounding boxes)
     TreePolygons_datasets = filter_degenerate_polygons(TreePolygons_datasets)
+
+    # Defensive guard: collapse exact duplicate annotations (same image + same
+    # geometry within a source). Upstream prediction CSVs have shipped doubled
+    # boxes before (e.g. NEON unsupervised), which silently inflated release
+    # counts. Geometry is now normalized to WKT, so identity is well-defined.
+    TreeBoxes_datasets = drop_duplicate_annotations(TreeBoxes_datasets, "TreeBoxes")
+    TreePoints_datasets = drop_duplicate_annotations(TreePoints_datasets, "TreePoints")
+    TreePolygons_datasets = drop_duplicate_annotations(TreePolygons_datasets, "TreePolygons")
 
     # Assign source-unique packaged filenames (<stem>_<source><ext>) so basenames
     # don't collide across sources; keeps the original path in 'orig_path' for copy.

--- a/data_prep/process_neon_unsupervised.py
+++ b/data_prep/process_neon_unsupervised.py
@@ -40,15 +40,38 @@ def format_neon_annotations(csv_glob_pattern: str, output_dir: str) -> Tuple[str
     csvs = glob.glob(csv_glob_pattern)
     if not csvs:
         raise ValueError(f"No CSV files found matching pattern: {csv_glob_pattern}")
-        
-    print(f"Found {len(csvs)} CSV files to process")
-    
+
+    # The output dir contains both per-site CSVs (e.g. ABBY_2019.csv, with
+    # confidence_mean/confidence_std) and a roll-up `all_annotations.csv` that
+    # holds the SAME boxes without the confidence columns. Globbing both ingests
+    # every box twice (once valued, once NaN-confidence), which silently doubled
+    # every annotation in past releases. Read only the per-site files.
+    csvs = [c for c in csvs if os.path.basename(c) != "all_annotations.csv"]
+    if not csvs:
+        raise ValueError(
+            "Only all_annotations.csv was found; expected per-site CSVs with "
+            "confidence columns to avoid duplicate boxes."
+        )
+
+    print(f"Found {len(csvs)} per-site CSV files to process")
+
     annotations = []
     for csv in csvs:
         df = pd.read_csv(csv)
         df["source"] = "Weinstein et al. 2018 unsupervised"
         annotations.append(df)
     annotations = pd.concat(annotations, ignore_index=True)
+
+    # Safety net in case any per-site file overlaps another: collapse exact box
+    # duplicates, preferring the copy that carries a confidence score.
+    box_id = ["image_path", "xmin", "ymin", "xmax", "ymax"]
+    if "confidence_mean" in annotations.columns:
+        annotations = annotations.sort_values("confidence_mean", na_position="last")
+    n_before = len(annotations)
+    annotations = annotations.drop_duplicates(subset=box_id, keep="first").reset_index(drop=True)
+    if len(annotations) < n_before:
+        print(f"Dropped {n_before - len(annotations)} duplicate boxes "
+              f"({n_before} -> {len(annotations)})")
 
     # Extract siteID and tile_name from the filename
     annotations["siteID"] = annotations["image_path"].apply(lambda x: x.split("_")[1])
@@ -57,14 +80,14 @@ def format_neon_annotations(csv_glob_pattern: str, output_dir: str) -> Tuple[str
     print(f"Number of sites: {annotations['siteID'].nunique()}")
     print(f"Number of tiles: {annotations['tile_name'].nunique()}")
 
-    # Sample up to 10 tiles per site, keeping all trees from sampled tiles
+    # Sample up to 30 tiles per site, keeping all trees from sampled tiles
     unique_tiles = annotations[["siteID", "tile_name"]].drop_duplicates()
     sampled_tiles = pd.concat([
-        grp.sample(min(len(grp), 10), random_state=42)
+        grp.sample(min(len(grp), 30), random_state=42)
         for _, grp in unique_tiles.groupby("siteID")
     ])
     annotations = annotations.merge(sampled_tiles[["siteID", "tile_name"]], on=["siteID", "tile_name"])
-    print(f"After sampling (10 tiles per site): {len(annotations)} annotations")
+    print(f"After sampling (30 tiles per site): {len(annotations)} annotations")
 
     # Create metadata column
     annotations["metadata"] = annotations.apply(lambda row: f"{row['siteID']}_{row['tile_name']}", axis=1)

--- a/docs/combined_results_table.txt
+++ b/docs/combined_results_table.txt
@@ -3,73 +3,73 @@ Table X. Combination of Tables 2-4
 Paste the block below into Google Docs / Word to create a table.
 
 Geometry	Model	Fine-tuned	Split	Tree Counting (mae)	Tree Detection (recall, precision)	Tree Segmentation (mAP)
-Points	CenterNet	✓	Random	TBD	TBD	TBD
-Points	TreeFormer	✗	Random	63.517	0.239, 0.777	N/A
-Points	SAM3	✗	Random	58.343	0.181, 0.714	N/A
-Points	DeepForest	✗	Random	58.422	0.175, 0.711	N/A
-Points	DeepForest	✓	Random	51.328	0.182, 0.761	N/A
-Points	TreeFormer	✗	Zero-shot	19.567	0.290, 0.884	N/A
-Points	DeepForest	✗	Zero-shot	32.782	0.214, 0.830	N/A
-Points	SAM3	✗	Zero-shot	18.578	0.124, 0.766	N/A
-Points	DeepForest	✓	Zero-shot	49.989	0.198, 0.611	N/A
-Boxes	DeepForest	✗	Random	25.755	0.404, 0.734	0.138
-Boxes	DeepForest	✓	Random	28.101	0.489, 0.671	0.289
-Boxes	SAM3	✗	Random	39.986	0.159, 0.610	0.114
-Boxes	DeepForest	✗	Zero-shot	36.252	0.416, 0.959	0.100
-Boxes	DeepForest	✓	Zero-shot	43.448	0.452, 0.896	0.275
-Boxes	SAM3	✗	Zero-shot	70.331	0.201, 0.810	0.130
-Polygons	Mask R-CNN	✓	Random	N/A	0.662, 0.898	0.407
-Polygons	SAM3	✗	Random	N/A	0.304, 0.656	0.209
-Polygons	DeepForest	✗	Random	N/A	0.082, 0.004	0.078
-Polygons	SAM3	✗	Zero-shot	N/A	0.224, 0.734	0.185
-Polygons	Mask R-CNN	✓	Zero-shot	N/A	0.197, 0.886	0.101
-Polygons	DeepForest	✗	Zero-shot	N/A	0.106, 0.000	0.098
-Polygons	SAM3	✗	Cross-geometry	N/A	0.224, 0.734	0.185
+Points	TreeFormer	✗	Random	56.435	0.239, 0.775	N/A
+Points	SAM3	✗	Random	54.593	0.182, 0.711	N/A
+Points	TreeFormer	✓	Random	57.461	0.276, 0.784	N/A
+Points	TreeFormer	✗	Zero-shot	15.717	0.291, 0.882	N/A
+Points	SAM3	✗	Zero-shot	14.878	0.129, 0.759	N/A
+Points	TreeFormer	✓	Zero-shot	17.024	0.315, 0.869	N/A
+Boxes	DeepForest	✗	Random	24.069	0.407, 0.731	0.143
+Boxes	SAM3	✗	Random	37.868	0.190, 0.608	0.121
+Boxes	DeepForest	✓	Random	26.761	0.526, 0.650	0.314
+Boxes	DeepForest	✗	Zero-shot	28.741	0.432, 0.962	0.101
+Boxes	SAM3	✗	Zero-shot	62.323	0.209, 0.798	0.139
+Boxes	DeepForest	✓	Zero-shot	28.068	0.535, 0.908	0.334
+Polygons	SAM3	✗	Random	N/A	0.282, 0.619	0.064
+Polygons	detectree2	✗	Random	N/A	0.480, 0.891	0.167
+Polygons	Mask R-CNN	✓	Random	N/A	0.626, 0.900	0.304
+Polygons	SAM3	✗	Zero-shot	N/A	0.214, 0.663	0.131
+Polygons	detectree2	✗	Zero-shot	N/A	0.520, 0.945	0.366
+Polygons	Mask R-CNN	✓	Zero-shot	N/A	0.124, 0.814	N/A*
+Polygons	SAM3	✗	Cross-geometry	N/A	0.214, 0.663	0.131
 Polygons	TreeFormer+SAM2	✗	Cross-geometry	N/A	0.377, 0.828	0.254
 
 Notes / provenance:
-- Most numbers from v0.16 runs completed 2026-05-30 unless otherwise noted.
-- Polygons Mask R-CNN ✓ Zero-shot updated 2026-06-04 from retrained model (job 33924927_1).
-- DeepForest ✗ Boxes (random, zeroshot): new eval running (jobs 33924928_0,1); numbers will update.
-- SAM3 ✗ all geometry zeroshot: new eval running (job 33924930_1); numbers will update.
-- DeepForest ✓ Points (random, zeroshot): new training run underway (job 33913952_0,1); numbers will update.
-- Polygons Mask R-CNN ✓ Random: new training run underway (job 33924927_0); numbers will update.
-- FAILED/needs resubmit: mt_train_boxes (memory flag conflict), mt_eval_treeformer (deepforest point.yaml missing), mt_eval_sam3 random (missing TreeBoxes_supervised_v0.16 image file).
+- Numbers regenerated 2026-06-10 from the latest result files (overnight runs of
+  2026-06-09). Earlier provenance (v0.16, 2026-05-30) superseded.
 - Columns: "Tree Counting" = counting_mae (gated on per-source `complete` flag).
-  "Tree Detection" = (recall, precision): for Points, recall is KeypointAccuracy and
+  "Tree Detection" = (recall, precision): for Points, recall is keypoint_acc and
   precision is maskaware_keypoint_precision; for Boxes and Polygons, recall is average
   recall and precision is maskaware_precision.
-  "Tree Segmentation (mAP)": for Boxes this is AP50; for Polygons this is mask IoU
-  accuracy (fraction of predictions matched to ground truth by mask IoU); N/A for Points
-  (centroid outputs only).
-- Points "CenterNet ✓ Random": no CenterNet model exists in this repo. The fine-tuned
-  points model is DeepForest/RetinaNet (training/points/train_points.py). Row left TBD.
-- Boxes counting_mae is now available (gated on complete flag); previous table notes
-  stating "Boxes have no Counting MAE" are no longer accurate.
-- Polygons counting_mae = N/A (no polygon sources carry the complete flag).
-- Polygons AP50 = -1 (sentinel; not computed by the polygon evaluator). Segmentation
-  column uses mask IoU accuracy instead.
-- DeepForest ✗ Polygons maskaware_precision is near-zero (0.004 random, 0.000 zeroshot).
-  DeepForest outputs bounding boxes, not masks; the polygon evaluator's mask-aware
-  precision collapses when the model produces no valid segmentation masks.
-- TreeFormer cross-geometry: 0 test images in this split — vacuous; omitted from table.
-- TreeFormer+SAM3 cross-geometry: TreeFormer (weecology/deepforest-tree-point) runs on polygon-annotated images
-  to predict centroids; those centroids are then used as SAM3 point prompts (no text, point_box_size=12px)
-  via deepforest branch bw4sz/cursor/sam3-polygon-integration to generate polygon masks.
-  Run: existing_models/treeformer_sam3/eval_polygons_crossgeometry.py via slurm/eval_treeformer_sam3.sbatch.
-  Job 33646192 completed 2026-06-01. Very low recall (0.004) — cross-geometry transfer is difficult;
-  high precision (0.912) indicates the polygons that are generated match well when they exist.
+  "Tree Segmentation (mAP)": for Boxes this is AP50; for Polygons this is now AP50
+  (map_50) as well, computed by the polygon evaluator after the 2026-06-08 fix
+  (binarize GT masks + AP50/map_50; commit b2ff776). N/A for Points (centroid outputs).
+- Points fine-tuned = DeepForest TreeFormer stack (training/points/train.py,
+  --extra treeformer). Random from training/points/outputs/random (2026-06-10),
+  zeroshot from training/points/outputs/zeroshot (2026-06-09). No DeepForest point
+  baseline in the current results set (only TreeFormer ✗ and SAM3 ✗).
+- Boxes fine-tuned = DeepForest (training/boxes/outputs/{random,zeroshot}, 2026-06-09).
+  Boxes counting_mae is gated on the complete flag.
+- Polygons fine-tuned = Mask R-CNN (torchvision maskrcnn_resnet50_fpn_v2).
+  Random from training/polygons/outputs/lr_sweep/random_lr1e-5 (2026-06-09, post-fix
+  evaluator with real AP50). Zeroshot from training/polygons/outputs/zeroshot
+  (2026-06-08) — pre-fix evaluator: AP50 not computed (sentinel -1) and the
+  recall/precision were measured before GT-mask binarization, so this row is not
+  directly comparable to the post-fix random row. Marked N/A* in the segmentation
+  column; rerun the zeroshot polygon eval to refresh.
+- detectree2 added as a TreePolygons pretrained baseline (✗): random/zeroshot from
+  existing_models/detectree2/outputs/{random,zeroshot} (2026-06-08). Replaces the
+  prior degenerate DeepForest-✗-on-polygons rows (DeepForest emits boxes, not masks;
+  the mask-aware precision collapsed there). No current DeepForest polygon eval exists.
+- TreeFormer cross-geometry (points-only) is vacuous (0 test images) and omitted.
 - SAM3 cross-geometry Polygons: same test sources as zero-shot for the polygon split;
-  values are identical (0.224, 0.734 / 0.185).
+  values are identical (0.214, 0.663 / 0.131).
+- TreeFormer+SAM2 cross-geometry retained from the prior table (0.377, 0.828 / 0.254);
+  TreeFormer (weecology/deepforest-tree-point) predicts centroids on polygon-annotated
+  images, which seed SAM3 point prompts (no text, point_box_size=12px) to generate
+  masks. A newer treeformer_sam3 cross-geometry run exists
+  (existing_models/treeformer_sam3/outputs/crossgeometry_kcl, 2026-06-08:
+  recall 0.234, prec 0.960, AP50 0.145) but was intentionally not adopted here.
+- Polygons counting_mae = N/A (no polygon sources carry the complete flag).
 
-Source files (v0.16 runs):
-- Points (unfine-tuned DF):   logs/slurm/20260530-153639/mt_df_points_33529304_{0,1}.out
-- Points (TreeFormer):        logs/slurm/20260530-153639/mt_df_treeformer_points_33529305_{0,1}.out
-- Points (SAM3):              logs/slurm/20260530-153639/mt_sam3_points_33529308_{0,1}.out
-- Points (fine-tuned):        training/points/outputs/{random,zeroshot}/results_*.txt
-- Boxes (unfine-tuned DF):    logs/slurm/20260530-153639/mt_df_boxes_33529306_{0,1}.out
-- Boxes (SAM3):               logs/slurm/20260530-153639/mt_sam3_boxes_33529309_{0,1}.out
-- Boxes (fine-tuned):         training/boxes/outputs/{random,zeroshot}/results_*.txt
-- Polygons (unfine-tuned DF): logs/slurm/20260530-153639/mt_df_polygons_33529307_{0,1}.out
-- Polygons (SAM3):            logs/slurm/20260530-153639/mt_sam3_polygons_33529310_{0,1,2}.out
-- Polygons (fine-tuned):      training/polygons/outputs/{random,zeroshot}/results_*.txt
+Source files (latest runs):
+- Points (TreeFormer ✗):      existing_models/treeformer/outputs/{random,zeroshot}/results_points_*.txt
+- Points (SAM3 ✗):            existing_models/sam3/outputs/{random,zeroshot}/results_points_*.txt
+- Points (TreeFormer ✓):      training/points/outputs/{random,zeroshot}/results_*.txt
+- Boxes (DeepForest ✗):       existing_models/deepforest/outputs/{random,zeroshot}/results_boxes_*.txt
+- Boxes (SAM3 ✗):             existing_models/sam3/outputs/{random,zeroshot}/results_boxes_*.txt
+- Boxes (DeepForest ✓):       training/boxes/outputs/{random,zeroshot}/results_*.txt
+- Polygons (SAM3 ✗):          existing_models/sam3/outputs/{random,zeroshot}/results_polygons_*.txt
+- Polygons (detectree2 ✗):    existing_models/detectree2/outputs/{random,zeroshot}/results_polygons_*.txt
+- Polygons (Mask R-CNN ✓):    training/polygons/outputs/lr_sweep/random_lr1e-5/results_random.txt (random),
+                              training/polygons/outputs/zeroshot/results_zeroshot.txt (zeroshot, pre-fix)

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -47,9 +47,9 @@ branch until merged to main).
 
 | Model | Fine-tuned | Counting MAE | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| TreeFormer | ✗ | pending | pending | <small>`uv run python existing_models/treeformer/eval_points.py --split-scheme random`</small> |
-| SAM3 | ✗ | 26.675 | 0.714 | <small>`uv run python existing_models/sam3/eval_points.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
-| TreeFormer | ✓ | pending | pending | <small>`uv run --extra treeformer python training/points/train.py --split-scheme random`</small> |
+| TreeFormer | ✗ | 56.435 | 0.775 | <small>`uv run python existing_models/treeformer/eval_points.py --split-scheme random`</small> |
+| SAM3 | ✗ | 54.593 | 0.711 | <small>`uv run python existing_models/sam3/eval_points.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| TreeFormer | ✓ | 57.461 | 0.784 | <small>`uv run --extra treeformer python training/points/train.py --split-scheme random`</small> |
 
 ### Zeroshot split
 
@@ -59,9 +59,9 @@ released checkpoint with no MillionTrees training at all.
 
 | Model | Fine-tuned | Counting MAE | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| TreeFormer | ✗ | pending | pending | <small>`uv run python existing_models/treeformer/eval_points.py --split-scheme zeroshot`</small> |
-| SAM3 | ✗ | 51.860 | 0.544 | <small>`uv run python existing_models/sam3/eval_points.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
-| TreeFormer | ✓ | pending | pending | <small>`uv run --extra treeformer python training/points/train.py --split-scheme zeroshot`</small> |
+| TreeFormer | ✗ | 15.717 | 0.882 | <small>`uv run python existing_models/treeformer/eval_points.py --split-scheme zeroshot`</small> |
+| SAM3 | ✗ | 14.878 | 0.759 | <small>`uv run python existing_models/sam3/eval_points.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
+| TreeFormer | ✓ | 17.024 | 0.869 | <small>`uv run --extra treeformer python training/points/train.py --split-scheme zeroshot`</small> |
 
 ### Cross-geometry
 
@@ -75,17 +75,17 @@ released checkpoint with no MillionTrees training at all.
 
 | Model | Fine-tuned | Avg Recall | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| DeepForest | ✓ | 0.721 | 0.610 | <small>`uv run python training/boxes/train.py --split-scheme random`</small> |
-| DeepForest | ✗ | 0.414 | 0.760 | <small>`uv run python existing_models/deepforest/eval_boxes.py --split-scheme random`</small> |
-| SAM3 | ✗ | 0.175 | 0.619 | <small>`uv run python existing_models/sam3/eval_boxes.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| DeepForest | ✓ | 0.526 | 0.650 | <small>`uv run python training/boxes/train.py --split-scheme random`</small> |
+| DeepForest | ✗ | 0.407 | 0.731 | <small>`uv run python existing_models/deepforest/eval_boxes.py --split-scheme random`</small> |
+| SAM3 | ✗ | 0.190 | 0.608 | <small>`uv run python existing_models/sam3/eval_boxes.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
 
 ### Zero-shot
 
 | Model | Fine-tuned | Avg Recall | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| DeepForest | ✓ | 0.460 | 0.900 | <small>`uv run python training/boxes/train.py --split-scheme zeroshot`</small> |
-| DeepForest | ✗ | 0.416 | 0.959 | <small>`uv run python existing_models/deepforest/eval_boxes.py --split-scheme zeroshot`</small> |
-| SAM3 | ✗ | 0.201 | 0.810 | <small>`uv run python existing_models/sam3/eval_boxes.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
+| DeepForest | ✓ | 0.535 | 0.908 | <small>`uv run python training/boxes/train.py --split-scheme zeroshot`</small> |
+| DeepForest | ✗ | 0.432 | 0.962 | <small>`uv run python existing_models/deepforest/eval_boxes.py --split-scheme zeroshot`</small> |
+| SAM3 | ✗ | 0.209 | 0.798 | <small>`uv run python existing_models/sam3/eval_boxes.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
 
 ### Cross-geometry
 
@@ -100,27 +100,35 @@ released checkpoint with no MillionTrees training at all.
 
 ## TreePolygons
 
-Fine-tuned (✓) uses Mask R-CNN (`training/polygons/train.py`). Pretrained (✗) uses SAM3.
+Fine-tuned (✓) uses Mask R-CNN (`training/polygons/train.py`). Pretrained (✗) uses
+SAM3 and detectree2.
 
 ### Random
 
 | Model | Fine-tuned | Avg Mask Accuracy | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| Mask R-CNN | ✓ | 0.232 | 0.872 | <small>`uv run python training/polygons/train.py --split-scheme random`</small> |
-| SAM3 | ✗ | 0.223 | 0.681 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
+| Mask R-CNN | ✓ | 0.416 | 0.900 | <small>`uv run python training/polygons/train.py --split-scheme random`</small> |
+| detectree2 | ✗ | 0.304 | 0.891 | <small>`uv run python existing_models/detectree2/eval_polygons.py --split-scheme random`</small> |
+| SAM3 | ✗ | 0.186 | 0.619 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme random --hf-token $HF_TOKEN`</small> |
 
 ### Zero-shot
 
 | Model | Fine-tuned | Avg Mask Accuracy | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| Mask R-CNN | ✓ | 0.146 | 0.758 | <small>`uv run python training/polygons/train.py --split-scheme zeroshot`</small> |
-| SAM3 | ✗ | 0.180 | 0.719 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
+| detectree2 | ✗ | 0.375 | 0.945 | <small>`uv run python existing_models/detectree2/eval_polygons.py --split-scheme zeroshot`</small> |
+| SAM3 | ✗ | 0.165 | 0.663 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme zeroshot --hf-token $HF_TOKEN`</small> |
+| Mask R-CNN | ✓ | 0.064 | 0.814 | <small>`uv run python training/polygons/train.py --split-scheme zeroshot`</small> |
+
+> **Note:** The Mask R-CNN ✓ zeroshot row is from the pre-fix polygon evaluator
+> (before GT-mask binarization / AP50; commit b2ff776) and is not directly comparable
+> to the post-fix random row above. Rerun to refresh.
 
 ### Cross-geometry
 
 | Model | Fine-tuned | Avg Mask Accuracy | Mask-Aware Precision | Script |
 |---|:---:|---|---|---|
-| SAM3 | ✗ | pending | pending | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme crossgeometry --hf-token $HF_TOKEN`</small> |
+| TreeFormer+SAM2 | ✗ | 0.254 | 0.828 | <small>`uv run python existing_models/treeformer_sam3/eval_polygons_crossgeometry.py`</small> |
+| SAM3 | ✗ | 0.165 | 0.663 | <small>`uv run python existing_models/sam3/eval_polygons.py --device cuda --split-scheme crossgeometry --hf-token $HF_TOKEN`</small> |
 
 ![TreePolygons: model predictions by split](leaderboard_predictions_polygons.png)
 

--- a/generate_dataset_report.py
+++ b/generate_dataset_report.py
@@ -119,21 +119,40 @@ def read_random_csv_counts_from_zip(url: str) -> Optional[dict]:
             name = sorted(candidates, key=lambda s: s.count("/"))[0]
             with zf.open(name) as f:
                 reader = csv.DictReader(io.TextIOWrapper(f, encoding="utf-8"))
-                num_rows = 0
-                filenames = set()
-                sources = set()
+                # Track counts split by supervision type. A source is treated as
+                # unsupervised if its name contains 'unsupervised' (matching the
+                # loader's default '*unsupervised*' exclusion pattern).
+                stats = {
+                    "supervised": {"rows": 0, "filenames": set(), "sources": set()},
+                    "unsupervised": {"rows": 0, "filenames": set(), "sources": set()},
+                }
                 for row in reader:
-                    num_rows += 1
+                    src = row.get("source")
+                    key = "unsupervised" if src and "unsupervised" in src.lower() else "supervised"
+                    stats[key]["rows"] += 1
                     fn = row.get("filename")
                     if fn:
-                        filenames.add(fn)
-                    src = row.get("source")
+                        stats[key]["filenames"].add(fn)
                     if src:
-                        sources.add(src)
+                        stats[key]["sources"].add(src)
+
+                def summarize(group):
+                    return {
+                        "images": len(group["filenames"]),
+                        "annotations": group["rows"],
+                        "sources": len(group["sources"]),
+                    }
+
+                sup = summarize(stats["supervised"])
+                unsup = summarize(stats["unsupervised"])
+                all_filenames = stats["supervised"]["filenames"] | stats["unsupervised"]["filenames"]
+                all_sources = stats["supervised"]["sources"] | stats["unsupervised"]["sources"]
                 return {
-                    "images": len(filenames),
-                    "annotations": num_rows,
-                    "sources": len(sources),
+                    "images": len(all_filenames),
+                    "annotations": sup["annotations"] + unsup["annotations"],
+                    "sources": len(all_sources),
+                    "supervised": sup,
+                    "unsupervised": unsup,
                 }
     except zipfile.BadZipFile:
         # Some URLs may point to non-zip resources; treat as missing stats.
@@ -198,14 +217,15 @@ def generate_dataset_report(output_path=None, include_test_results=False, test_e
     # Summary table
     report_content.append('## Dataset Summary')
     report_content.append('')
-    report_content.append('| Dataset | Latest Version | Size (GB) | Images | Annotations | Sources | Download URL |')
-    report_content.append('|---------|----------------|-----------|--------|-------------|---------|--------------|')
-    
+    report_content.append('| Dataset | Latest Version | Size (GB) | Supervision | Images | Annotations | Sources | Download URL |')
+    report_content.append('|---------|----------------|-----------|-------------|--------|-------------|---------|--------------|')
+
     total_size = 0
-    
+    empty_counts = {"images": 0, "annotations": 0, "sources": 0}
+
     for dataset_name, dataset_class in datasets_info:
         versions_dict = get_versions_dict(dataset_class)
-        
+
         if versions_dict:
             # Get latest version (highest version number)
             def version_sort_key(v):
@@ -213,7 +233,7 @@ def generate_dataset_report(output_path=None, include_test_results=False, test_e
                     return tuple(map(int, v.split('.')))
                 except ValueError:
                     return (0, 0)
-            
+
             latest_version = max(versions_dict.keys(), key=version_sort_key)
             latest_info = versions_dict[latest_version]
             url = latest_info.get('download_url', 'N/A')
@@ -224,24 +244,40 @@ def generate_dataset_report(output_path=None, include_test_results=False, test_e
                 size_bytes_meta = 0
             size_bytes_int = get_on_disk_size_bytes(url, size_bytes_meta)
             total_size += size_bytes_int
-            counts = read_random_csv_counts_from_zip(url) or {"images": 0, "annotations": 0, "sources": 0}
-            
+            counts = read_random_csv_counts_from_zip(url) or dict(empty_counts)
+
             # Handle missing URLs
             if not url or url.strip() == '':
                 url = 'N/A'
-            
+
             # Truncate URL for display
             display_url = url
             if url != 'N/A' and len(url) > 50:
                 display_url = url[:47] + "..."
-            report_content.append(
-                f'| {dataset_name} | {latest_version} | {format_gb(size_bytes_int)} | '
-                f'{counts["images"]} | {counts["annotations"]} | {counts["sources"]} | {display_url} |'
-            )
+
+            # One sub-row per supervision type, then a Total row for the dataset.
+            sup = counts.get("supervised", dict(empty_counts))
+            unsup = counts.get("unsupervised", dict(empty_counts))
+            rows = [
+                ('Supervised', sup),
+                ('Unsupervised', unsup),
+                ('Total', counts),
+            ]
+            for i, (label, c) in enumerate(rows):
+                # Only repeat dataset/version/size/url on the first sub-row.
+                name_cell = dataset_name if i == 0 else ''
+                version_cell = latest_version if i == 0 else ''
+                size_cell = format_gb(size_bytes_int) if i == 0 else ''
+                url_cell = display_url if i == 0 else ''
+                label_cell = f'**{label}**' if label == 'Total' else label
+                report_content.append(
+                    f'| {name_cell} | {version_cell} | {size_cell} | {label_cell} | '
+                    f'{c["images"]} | {c["annotations"]} | {c["sources"]} | {url_cell} |'
+                )
         else:
-            report_content.append(f'| {dataset_name} | N/A | N/A | N/A | N/A | N/A | N/A |')
-    
-    report_content.append(f'| **Total** | - | **{format_gb(total_size)}** | - | - | - | - |')
+            report_content.append(f'| {dataset_name} | N/A | N/A | - | N/A | N/A | N/A | N/A |')
+
+    report_content.append(f'| **Total** | - | **{format_gb(total_size)}** | - | - | - | - | - |')
     report_content.append('')
 
     # Detailed version information

--- a/training/boxes/eval.py
+++ b/training/boxes/eval.py
@@ -6,13 +6,15 @@ import os
 import sys
 import torch
 from deepforest import main as df_main
-from training.boxes.train import MillionTreesBatchAdapter, evaluate
+from training.boxes.train import _AdaptCollate, evaluate
 from milliontrees import get_dataset
 
-# The checkpoint was saved when train.py ran as __main__, so pickle
-# stored the adapter as __main__.MillionTreesBatchAdapter.  Inject it here
-# so deserialization can resolve that reference.
-sys.modules['__main__'].MillionTreesBatchAdapter = MillionTreesBatchAdapter
+# The checkpoint was saved when train.py ran as __main__, so pickle stored the
+# batch adapter under __main__.  Inject it here so deserialization can resolve
+# that reference. The class was renamed _AdaptCollate; alias the old name too so
+# checkpoints saved before the rename still load.
+sys.modules['__main__']._AdaptCollate = _AdaptCollate
+sys.modules['__main__'].MillionTreesBatchAdapter = _AdaptCollate
 
 
 def _load_model(checkpoint_path):

--- a/training/boxes/pretrain_backbone_for_polygons.py
+++ b/training/boxes/pretrain_backbone_for_polygons.py
@@ -7,12 +7,12 @@ from pathlib import Path
 
 import pytorch_lightning as pl
 import torch
+from torch.utils.data import DataLoader
 
 from deepforest import main as df_main
 
 from milliontrees import get_dataset
-from milliontrees.common.data_loaders import get_eval_loader, get_train_loader
-from training.boxes.train_boxes import MillionTreesBatchAdapter, evaluate
+from training.boxes.train import _AdaptCollate, evaluate
 
 
 def _flatten_numeric_metrics(results):
@@ -96,17 +96,30 @@ def main():
     if len(train_subset) == 0:
         raise RuntimeError("No training samples for this split; cannot pretrain.")
 
-    train_loader = get_train_loader(
-        "standard", train_subset, batch_size=args.batch_size, num_workers=args.num_workers
-    )
-    val_loader = get_eval_loader(
-        "standard", test_subset, batch_size=args.batch_size, num_workers=args.num_workers
-    )
-    has_val = len(val_loader) > 0
+    # Real DataLoaders (not a custom iterable) so Lightning can inject a
+    # DistributedSampler under DDP and shard data across GPUs. The collate_fn
+    # translates MillionTrees batches into DeepForest's (images, targets, paths).
+    adapt_collate = _AdaptCollate(train_subset.collate, box_dataset._filename_id_to_code)
+    has_val = len(test_subset) > 0
 
-    filename_id_to_path = box_dataset._filename_id_to_code
-    train_adapted = MillionTreesBatchAdapter(train_loader, filename_id_to_path)
-    val_adapted = MillionTreesBatchAdapter(val_loader, filename_id_to_path) if has_val else None
+    train_adapted = DataLoader(
+        train_subset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=adapt_collate,
+        num_workers=args.num_workers,
+    )
+    val_adapted = (
+        DataLoader(
+            test_subset,
+            batch_size=args.batch_size,
+            shuffle=False,
+            collate_fn=adapt_collate,
+            num_workers=args.num_workers,
+        )
+        if has_val
+        else None
+    )
 
     model = df_main.deepforest(
         config_args={

--- a/training/points/eval.py
+++ b/training/points/eval.py
@@ -14,7 +14,11 @@ from training.points.train import evaluate
 
 def main():
     parser = argparse.ArgumentParser(description="Eval a TreeFormer TreePoints checkpoint.")
-    parser.add_argument("--checkpoint", type=str, required=True, help="Path to .ckpt file")
+    parser.add_argument("--checkpoint", type=str, required=True,
+                        help="Lightning .ckpt file, or a HuggingFace repo id / local "
+                             "HF checkpoint dir (config.json + model.safetensors)")
+    parser.add_argument("--revision", type=str, default="main",
+                        help="HF revision/tag (ignored for .ckpt files and local dirs)")
     parser.add_argument("--root-dir", type=str,
                         default=os.environ.get("MT_ROOT", "/orange/ewhite/web/public/MillionTrees"))
     parser.add_argument("--split-scheme", type=str, default="zeroshot",
@@ -34,8 +38,21 @@ def main():
     elif args.viz_dir == "":
         args.viz_dir = None
 
-    print(f"Loading checkpoint: {args.checkpoint}")
-    model = df_main.deepforest.load_from_checkpoint(args.checkpoint, weights_only=False)
+    # Two checkpoint formats: a Lightning .ckpt (load_from_checkpoint), or a
+    # HuggingFace-format TreeFormer checkpoint (repo id, or local dir with
+    # config.json + model.safetensors). The latter must be loaded the same way
+    # the polygon eval and points training do: build a treeformer deepforest,
+    # then load_model() the weights.
+    if args.checkpoint.endswith(".ckpt") and os.path.isfile(args.checkpoint):
+        print(f"Loading Lightning checkpoint: {args.checkpoint}")
+        model = df_main.deepforest.load_from_checkpoint(args.checkpoint, weights_only=False)
+    else:
+        print(f"Loading TreeFormer weights: {args.checkpoint} (revision={args.revision})")
+        model = df_main.deepforest(config_args={
+            "architecture": "treeformer",
+            "model": {"name": args.checkpoint, "revision": args.revision},
+        })
+        model.load_model(args.checkpoint, revision=args.revision)
     model.eval()
     if torch.cuda.is_available():
         model = model.cuda()

--- a/training/slurm/eval_points.sbatch
+++ b/training/slurm/eval_points.sbatch
@@ -30,7 +30,7 @@ echo "Checkpoint: $CKPT"
 VIZ_DIR="outputs/viz/trained_points/${SPLIT}"
 mkdir -p "$VIZ_DIR"
 
-uv run python training/points/eval_checkpoint.py \
+uv run python training/points/eval.py \
   --checkpoint "$CKPT" \
   --root-dir "$ROOT_DIR" \
   --split-scheme "$SPLIT" \


### PR DESCRIPTION
Packaging (package_datasets.py, process_neon_unsupervised.py):
- normalize_unsupervised_sources() + verify_unsupervised_sources() bake the canonical 'unsupervised' suffix into every released CSV (catches SPREAD/Feng regression) and fail loudly if it's lost upstream.
- drop_duplicate_annotations() collapses exact dup boxes/points/polygons; NEON processor skips all_annotations.csv roll-up to stop double-counting and samples up to 30 tiles/site (was 10).

Docs (leaderboard.md, combined_results_table.txt): regenerate from 2026-06-09 runs, add detectree2 polygon baseline, refresh point/box/polygon numbers and provenance notes.

Reporting (generate_dataset_report.py): split summary counts by supervised / unsupervised with a per-dataset Total row.

Training/eval: rename batch adapter to _AdaptCollate (alias old name for old checkpoints), use real DataLoaders in polygon backbone pretrain so DDP can shard, support HF-format TreeFormer checkpoints in points eval, fix sbatch to call eval.py.